### PR TITLE
use numeric up down controls

### DIFF
--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:properties="clr-namespace:AnnoDesigner.Properties"
         Title="Anno Designer"
         Icon="/AnnoDesigner;component/icon.ico"
-        Height="{Binding Source={x:Static properties:Settings.Default},Path=MainWindowHeight, Mode=TwoWay}" 
+        Height="{Binding Source={x:Static properties:Settings.Default},Path=MainWindowHeight, Mode=TwoWay}"
         Width="{Binding Source={x:Static properties:Settings.Default},Path=MainWindowWidth, Mode=TwoWay}"
         Top="{Binding Source={x:Static properties:Settings.Default},Path=MainWindowTop, Mode=TwoWay}"
         Left="{Binding Source={x:Static properties:Settings.Default},Path=MainWindowTop, Mode=TwoWay}"
@@ -20,13 +20,17 @@
         <DataTemplate DataType="{x:Type myUI:IconImage}">
             <StackPanel Orientation="Horizontal">
                 <Viewbox Margin="5">
-                    <Image Width="23" Height="23" Source="{Binding Path=Icon}" />
+                    <Image Width="23"
+                           Height="23"
+                           Source="{Binding Path=Icon}" />
                 </Viewbox>
-                <TextBlock Margin="0,5,5,5" VerticalAlignment="Center" Text="{Binding Path=DisplayName}" />
+                <TextBlock Margin="0,5,5,5"
+                           VerticalAlignment="Center"
+                           Text="{Binding Path=DisplayName}" />
             </StackPanel>
         </DataTemplate>
         <HierarchicalDataTemplate DataType="{x:Type my:AnnoObject}">
-            <TextBlock Text="{Binding Label}"/>
+            <TextBlock Text="{Binding Label}" />
         </HierarchicalDataTemplate>
         <l:MainWindow x:Key="localization"></l:MainWindow>
     </Window.Resources>
@@ -41,12 +45,24 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="27*" />
-            <ColumnDefinition Width="13*"/>
+            <ColumnDefinition Width="13*" />
             <ColumnDefinition Width="230" />
         </Grid.ColumnDefinitions>
-        <my:AnnoCanvas x:Name="annoCanvas" Grid.RowSpan="1" Grid.Row="1" RenderGrid="True" RenderIcon="True" RenderLabel="True" RenderStats="True" Grid.ColumnSpan="2" />
-        <GridSplitter Grid.Row="1" Width="6" Grid.Column="1" />
-        <Menu Name="Menu" Height="23" VerticalAlignment="Top" Grid.ColumnSpan="3">
+        <my:AnnoCanvas x:Name="annoCanvas"
+                       Grid.RowSpan="1"
+                       Grid.Row="1"
+                       RenderGrid="True"
+                       RenderIcon="True"
+                       RenderLabel="True"
+                       RenderStats="True"
+                       Grid.ColumnSpan="2" />
+        <GridSplitter Grid.Row="1"
+                      Width="6"
+                      Grid.Column="1" />
+        <Menu Name="Menu"
+              Height="23"
+              VerticalAlignment="Top"
+              Grid.ColumnSpan="3">
             <!--<Menu.Resources>
                
             </Menu.Resources>
@@ -58,78 +74,173 @@
                     <DockPanel HorizontalAlignment="Stretch"/>
                 </ItemsPanelTemplate>
             </Menu.ItemsPanel>-->
-            <MenuItem Header="{Binding Path=File}" TabIndex="20">
-                <MenuItem Header="{Binding Path=NewCanvas}" Command="ApplicationCommands.New" CommandTarget="{Binding ElementName=annoCanvas}" />
-                <MenuItem Header="{Binding Path=Open}" Command="ApplicationCommands.Open" CommandTarget="{Binding ElementName=annoCanvas}" />
-                <MenuItem Header="{Binding Path=Save}" Command="ApplicationCommands.Save" CommandTarget="{Binding ElementName=annoCanvas}" />
-                <MenuItem Header="{Binding Path=SaveAs}" Command="ApplicationCommands.SaveAs" CommandTarget="{Binding ElementName=annoCanvas}" />
+            <MenuItem Header="{Binding Path=File}"
+                      TabIndex="20">
+                <MenuItem Header="{Binding Path=NewCanvas}"
+                          Command="ApplicationCommands.New"
+                          CommandTarget="{Binding ElementName=annoCanvas}" />
+                <MenuItem Header="{Binding Path=Open}"
+                          Command="ApplicationCommands.Open"
+                          CommandTarget="{Binding ElementName=annoCanvas}" />
+                <MenuItem Header="{Binding Path=Save}"
+                          Command="ApplicationCommands.Save"
+                          CommandTarget="{Binding ElementName=annoCanvas}" />
+                <MenuItem Header="{Binding Path=SaveAs}"
+                          Command="ApplicationCommands.SaveAs"
+                          CommandTarget="{Binding ElementName=annoCanvas}" />
                 <Separator />
-                <MenuItem Header="{Binding Path=Exit}" Click="MenuItemCloseClick" />
+                <MenuItem Header="{Binding Path=Exit}"
+                          Click="MenuItemCloseClick" />
             </MenuItem>
-            <MenuItem Header="{Binding Path=Extras}" TabIndex="21">
+            <MenuItem Header="{Binding Path=Extras}"
+                      TabIndex="21">
                 <!--<MenuItem Header="Prefer local presets" IsCheckable="True" IsEnabled="False" />
                 <MenuItem Header="Apply automatic color scheme" IsEnabled="False" />-->
-                <MenuItem Header="{Binding Path=Normalize}" Click="MenuItemNormalizeClick" />
-                <MenuItem Header="{Binding Path=ResetZoom}" Click="MenuItemResetZoomClick" />
+                <MenuItem Header="{Binding Path=Normalize}"
+                          Click="MenuItemNormalizeClick" />
+                <MenuItem Header="{Binding Path=ResetZoom}"
+                          Click="MenuItemResetZoomClick" />
                 <Separator />
-                <MenuItem Header="{Binding Path=RegisterFileExtension}" Click="MenuItemRegisterExtensionClick" />
-                <MenuItem Header="{Binding Path=UnregisterFileExtension}" Click="MenuItemUnregisterExtensionClick" />
+                <MenuItem Header="{Binding Path=RegisterFileExtension}"
+                          Click="MenuItemRegisterExtensionClick" />
+                <MenuItem Header="{Binding Path=UnregisterFileExtension}"
+                          Click="MenuItemUnregisterExtensionClick" />
             </MenuItem>
-            <MenuItem Header="{Binding Path=Export}" TabIndex="22">
-                <MenuItem Header="{Binding Path=ExportImage}" Click="MenuItemExportImageClick" />
+            <MenuItem Header="{Binding Path=Export}"
+                      TabIndex="22">
+                <MenuItem Header="{Binding Path=ExportImage}"
+                          Click="MenuItemExportImageClick" />
                 <Separator />
-                <MenuItem Header="{Binding Path=UseCurrentZoomOnExportedImage}" IsCheckable="True" IsChecked="False" Name="MenuItemExportZoom" />
-                <MenuItem Header="{Binding Path=RenderSelectionHighlightsOnExportedImage}" IsCheckable="True" IsChecked="False" Name="MenuItemExportSelection" />
+                <MenuItem Header="{Binding Path=UseCurrentZoomOnExportedImage}"
+                          IsCheckable="True"
+                          IsChecked="False"
+                          Name="MenuItemExportZoom" />
+                <MenuItem Header="{Binding Path=RenderSelectionHighlightsOnExportedImage}"
+                          IsCheckable="True"
+                          IsChecked="False"
+                          Name="MenuItemExportSelection" />
             </MenuItem>
-            <MenuItem Name="LanguageMenu" Header="{Binding Path=Language}" TabIndex="23" Click="MenuItemLanguageClick" SubmenuClosed="LanguageMenuSubmenuClosed">
-                <MenuItem Header="English" IsCheckable="True" IsChecked="True" Name="MenuItemLanguageEng" />
-                <MenuItem Header="Deutsch" IsCheckable="True" IsChecked="False" Name="MenuItemLanguageGer" />
+            <MenuItem Name="LanguageMenu"
+                      Header="{Binding Path=Language}"
+                      TabIndex="23"
+                      Click="MenuItemLanguageClick"
+                      SubmenuClosed="LanguageMenuSubmenuClosed">
+                <MenuItem Header="English"
+                          IsCheckable="True"
+                          IsChecked="True"
+                          Name="MenuItemLanguageEng" />
+                <MenuItem Header="Deutsch"
+                          IsCheckable="True"
+                          IsChecked="False"
+                          Name="MenuItemLanguageGer" />
                 <!--<MenuItem Header="Français" IsCheckable="True" IsChecked="False" Name="MenuItemLanguageFra" />-->
                 <!--<MenuItem Header="Español" IsCheckable="True" IsChecked="False" Name="MenuItemLanguageEsp" />-->
                 <!--<MenuItem Header="Italiano" IsCheckable="True" IsChecked="False" Name="MenuItemLanguageIta" />-->
-                <MenuItem Header="Polski" IsCheckable="True" IsChecked="False" Name="MenuItemLanguagePol" />
-                <MenuItem Header="Русский" IsCheckable="True" IsChecked="False" Name="MenuItemLanguageRus" />
+                <MenuItem Header="Polski"
+                          IsCheckable="True"
+                          IsChecked="False"
+                          Name="MenuItemLanguagePol" />
+                <MenuItem Header="Русский"
+                          IsCheckable="True"
+                          IsChecked="False"
+                          Name="MenuItemLanguageRus" />
                 <!--<MenuItem Header="český" IsCheckable="True" IsChecked="False" Name="MenuItemLanguageCze" />-->
             </MenuItem>
-            <MenuItem Header="{Binding Path=ManageStats}" TabIndex="24" HorizontalAlignment="Right">
-                <MenuItem Header="{Binding Path=ShowStats}" 
-                          IsCheckable="True" 
-                          IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=StatsShowStats, Mode=TwoWay}" 
+            <MenuItem Header="{Binding Path=ManageStats}"
+                      TabIndex="24"
+                      HorizontalAlignment="Right">
+                <MenuItem Header="{Binding Path=ShowStats}"
+                          IsCheckable="True"
+                          IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=StatsShowStats, Mode=TwoWay}"
                           Click="MenuItemStatsShowStatsClick" />
                 <Separator></Separator>
-                <MenuItem Name="MenuItemStatsBuildingCount" 
-                          Header="{Binding Path=BuildingCount}" 
-                          IsCheckable="True" 
+                <MenuItem Name="MenuItemStatsBuildingCount"
+                          Header="{Binding Path=BuildingCount}"
+                          IsCheckable="True"
                           IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=StatsShowBuildingCount, Mode=TwoWay}"
-                          IsEnabled="{Binding Source={x:Static properties:Settings.Default},Path=StatsShowStats, Mode=OneWay}" 
+                          IsEnabled="{Binding Source={x:Static properties:Settings.Default},Path=StatsShowStats, Mode=OneWay}"
                           Click="MenuItemStatsBuildingCountClick" />
             </MenuItem>
-            <MenuItem Header="{Binding Path=Help}" TabIndex="25" HorizontalAlignment="Right">
-                <MenuItem Header="{Binding Path=Version}" Name="MenuItemVersion" IsEnabled="False" />
-                <MenuItem Header="{Binding Path=FileVersion}" Name="MenuItemFileVersion" IsEnabled="False" />
-                <MenuItem Header="{Binding Path=PresetsVersion}" Name="MenuItemPresetsVersion" IsEnabled="False" />
-                <MenuItem Header="{Binding Path=CheckForUpdates}" Click="MenuItemVersionCheckImageClick" />
-                <MenuItem Name="AutomaticUpdateCheck" IsCheckable="True" Header="{Binding Path=EnableAutomaticUpdateCheck}" IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=EnableAutomaticUpdateCheck, Mode=TwoWay}"></MenuItem>
+            <MenuItem Header="{Binding Path=Help}"
+                      TabIndex="25"
+                      HorizontalAlignment="Right">
+                <MenuItem Header="{Binding Path=Version}"
+                          Name="MenuItemVersion"
+                          IsEnabled="False" />
+                <MenuItem Header="{Binding Path=FileVersion}"
+                          Name="MenuItemFileVersion"
+                          IsEnabled="False" />
+                <MenuItem Header="{Binding Path=PresetsVersion}"
+                          Name="MenuItemPresetsVersion"
+                          IsEnabled="False" />
+                <MenuItem Header="{Binding Path=CheckForUpdates}"
+                          Click="MenuItemVersionCheckImageClick" />
+                <MenuItem Name="AutomaticUpdateCheck"
+                          IsCheckable="True"
+                          Header="{Binding Path=EnableAutomaticUpdateCheck}"
+                          IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=EnableAutomaticUpdateCheck, Mode=TwoWay}"></MenuItem>
                 <Separator />
-                <MenuItem Header="{Binding Path=GoToProjectHomepage}" Click="MenuItemHomepageClick" />
-                <MenuItem Header="{Binding Path=OpenWelcomePage}" Click="MenuItemOpenWelcomeClick"></MenuItem>
-                <MenuItem Header="{Binding Path=AboutAnnoDesigner}" Click="MenuItemAboutClick" />
+                <MenuItem Header="{Binding Path=GoToProjectHomepage}"
+                          Click="MenuItemHomepageClick" />
+                <MenuItem Header="{Binding Path=OpenWelcomePage}"
+                          Click="MenuItemOpenWelcomeClick"></MenuItem>
+                <MenuItem Header="{Binding Path=AboutAnnoDesigner}"
+                          Click="MenuItemAboutClick" />
             </MenuItem>
             <Separator />
-            <MenuItem Name="ShowGrid" Header="{Binding Path=ShowGrid}" IsCheckable="True" IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=ShowGrid, Mode=TwoWay}" Click="MenuItemGridClick" TabIndex="26" />
-            <MenuItem Name="ShowLabels" Header="{Binding Path=ShowLabels}" IsCheckable="True" IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=ShowLabels, Mode=TwoWay}" Click="MenuItemLabelClick" TabIndex="27" />
-            <MenuItem Name="ShowIcons" Header="{Binding Path=ShowIcons}" IsCheckable="True" IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=ShowIcons, Mode=TwoWay}" Click="MenuItemIconClick" TabIndex="28" />
+            <MenuItem Name="ShowGrid"
+                      Header="{Binding Path=ShowGrid}"
+                      IsCheckable="True"
+                      IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=ShowGrid, Mode=TwoWay}"
+                      Click="MenuItemGridClick"
+                      TabIndex="26" />
+            <MenuItem Name="ShowLabels"
+                      Header="{Binding Path=ShowLabels}"
+                      IsCheckable="True"
+                      IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=ShowLabels, Mode=TwoWay}"
+                      Click="MenuItemLabelClick"
+                      TabIndex="27" />
+            <MenuItem Name="ShowIcons"
+                      Header="{Binding Path=ShowIcons}"
+                      IsCheckable="True"
+                      IsChecked="{Binding Source={x:Static properties:Settings.Default},Path=ShowIcons, Mode=TwoWay}"
+                      Click="MenuItemIconClick"
+                      TabIndex="28" />
         </Menu>
-        <DockPanel Grid.Column="2" Grid.Row="1" LastChildFill="True">
-            <GroupBox Header="{Binding Path=BuildingSettings}" DockPanel.Dock="Top">
+        <DockPanel Grid.Column="2"
+                   Grid.Row="1"
+                   LastChildFill="True">
+            <GroupBox Header="{Binding Path=BuildingSettings}"
+                      DockPanel.Dock="Top">
                 <StackPanel>
-                    <DockPanel LastChildFill="False" Height="26">
+                    <DockPanel LastChildFill="False"
+                               Height="26">
                         <Label Content="{Binding Path=Size}" />
-                        <TextBox DockPanel.Dock="Right" Height="23" Name="textBoxHeight" Text="4" Width="40" TabIndex="1" />
-                        <Label Content="x" DockPanel.Dock="Right" />
-                        <TextBox DockPanel.Dock="Right" Height="23" Name="textBoxWidth" Text="4" Width="40" TabIndex="0" />
+                        <xctk:IntegerUpDown DockPanel.Dock="Right"
+                                            Height="23"
+                                            IsEnabled="True"
+                                            Name="textBoxHeight"
+                                            Width="50"
+                                            DefaultValue="4"
+                                            DisplayDefaultValueOnEmptyText="True"
+                                            Increment="1"
+                                            Minimum="1"
+                                            TabIndex="1" />
+                        <Label Content="x"
+                               DockPanel.Dock="Right" />
+                        <xctk:IntegerUpDown DockPanel.Dock="Right"
+                                            Height="23"
+                                            IsEnabled="True"
+                                            Name="textBoxWidth"
+                                            Width="50"
+                                            DefaultValue="4"
+                                            DisplayDefaultValueOnEmptyText="True"
+                                            Increment="1"
+                                            Minimum="1"
+                                            TabIndex="0" />
                     </DockPanel>
-                    <DockPanel LastChildFill="False" Height="26">
+                    <DockPanel LastChildFill="False"
+                               Height="26">
                         <Label Content="{Binding Path=Color}" />
                         <xctk:ColorPicker x:Name="colorPicker"
                                           DockPanel.Dock="Right"
@@ -142,47 +253,112 @@
                                           ShowRecentColors="True"
                                           AvailableColorsSortingMode="HueSaturationBrightness"
                                           StandardColorsHeader="Standard Color Presets"
-                                          SelectedColor="Red"/>
+                                          SelectedColor="Red" />
                     </DockPanel>
-                    <DockPanel LastChildFill="False" Height="26">
+                    <DockPanel LastChildFill="False"
+                               Height="26">
                         <Label Content="{Binding Path=Label}" />
-                        <TextBox DockPanel.Dock="Right" Height="23" IsEnabled="True" Name="textBoxLabel" Text="Building" Width="140" TabIndex="4" />
-                        <TextBox DockPanel.Dock="Right" Height="10" IsEnabled="False" Name="textBoxIdentifier" Text="" Visibility="Hidden" Width="140" />
-                        <TextBox DockPanel.Dock="Right" Height="10" IsEnabled="False" Name="textBoxInfluenceRange" Text="" Visibility="Hidden" Width="140" />
+                        <TextBox DockPanel.Dock="Right"
+                                 Height="23"
+                                 IsEnabled="True"
+                                 Name="textBoxLabel"
+                                 Text="Building"
+                                 Width="140"
+                                 TabIndex="4" />
+                        <TextBox DockPanel.Dock="Right"
+                                 Height="10"
+                                 IsEnabled="False"
+                                 Name="textBoxIdentifier"
+                                 Text=""
+                                 Visibility="Hidden"
+                                 Width="140" />
+                        <TextBox DockPanel.Dock="Right"
+                                 Height="10"
+                                 IsEnabled="False"
+                                 Name="textBoxInfluenceRange"
+                                 Text=""
+                                 Visibility="Hidden"
+                                 Width="140" />
                     </DockPanel>
-                    <DockPanel LastChildFill="False" Height="46">
-                        <Label Content="{Binding Path=Icon}" VerticalAlignment="Center" />
-                        <ComboBox DockPanel.Dock="Right" Width="140" Height="46" IsEnabled="True" Name="comboBoxIcon" SelectedIndex="0" TabIndex="6" TextSearch.TextPath="DisplayName">
+                    <DockPanel LastChildFill="False"
+                               Height="46">
+                        <Label Content="{Binding Path=Icon}"
+                               VerticalAlignment="Center" />
+                        <ComboBox DockPanel.Dock="Right"
+                                  Width="140"
+                                  Height="46"
+                                  IsEnabled="True"
+                                  Name="comboBoxIcon"
+                                  SelectedIndex="0"
+                                  TabIndex="6"
+                                  TextSearch.TextPath="DisplayName">
                             <ItemsPanelTemplate>
-                                <VirtualizingStackPanel
-                                    VirtualizingStackPanel.IsVirtualizing="True" 
-                                    VirtualizingStackPanel.VirtualizationMode="Recycling"></VirtualizingStackPanel>
+                                <VirtualizingStackPanel VirtualizingStackPanel.IsVirtualizing="True"
+                                                        VirtualizingStackPanel.VirtualizationMode="Recycling"></VirtualizingStackPanel>
                             </ItemsPanelTemplate>
                         </ComboBox>
                     </DockPanel>
-                    <DockPanel LastChildFill="False" Height="26">
+                    <DockPanel LastChildFill="False"
+                               Height="26">
                         <Label Content="{Binding Path=Radius}" />
-                        <TextBox DockPanel.Dock="Right" Height="23" IsEnabled="True" Name="textBoxRadius" Width="140" Text="0" TabIndex="8" />
+                        <xctk:DoubleUpDown DockPanel.Dock="Right"
+                                           Height="23"
+                                           IsEnabled="True"
+                                           Name="textBoxRadius"
+                                           Width="140"
+                                           DefaultValue="0"
+                                           DisplayDefaultValueOnEmptyText="True"
+                                           Increment="1"
+                                           Minimum="0"
+                                           TabIndex="8" />
                     </DockPanel>
                     <DockPanel LastChildFill="False">
                         <Label Content="{Binding Path=Options}" />
-                        <StackPanel Orientation="Vertical" DockPanel.Dock="Right">
-                            <CheckBox Content="{Binding Path=EnableLabel}" Name="checkBoxLabel" Margin="0,5,0,5" VerticalAlignment="Center" TabIndex="9" IsChecked="False" />
-                            <CheckBox Content="{Binding Path=Borderless}" Name="checkBoxBorderless" Margin="0,0,0,5" VerticalAlignment="Center" TabIndex="10" />
-                            <CheckBox Content="{Binding Path=Road}" Name="checkBoxRoad" Margin="0,0,0,5" VerticalAlignment="Center" TabIndex="11" />
+                        <StackPanel Orientation="Vertical"
+                                    DockPanel.Dock="Right">
+                            <CheckBox Content="{Binding Path=EnableLabel}"
+                                      Name="checkBoxLabel"
+                                      Margin="0,5,0,5"
+                                      VerticalAlignment="Center"
+                                      TabIndex="9"
+                                      IsChecked="False" />
+                            <CheckBox Content="{Binding Path=Borderless}"
+                                      Name="checkBoxBorderless"
+                                      Margin="0,0,0,5"
+                                      VerticalAlignment="Center"
+                                      TabIndex="10" />
+                            <CheckBox Content="{Binding Path=Road}"
+                                      Name="checkBoxRoad"
+                                      Margin="0,0,0,5"
+                                      VerticalAlignment="Center"
+                                      TabIndex="11" />
                         </StackPanel>
                     </DockPanel>
-                    <Button Click="ButtonPlaceBuildingClick" Content="{Binding Path=PlaceBuilding}" Height="23" TabIndex="12" />
+                    <Button Click="ButtonPlaceBuildingClick"
+                            Content="{Binding Path=PlaceBuilding}"
+                            Height="23"
+                            TabIndex="12" />
                 </StackPanel>
             </GroupBox>
-            <GroupBox Header="Building presets - not loaded" Name="GroupBoxPresets" IsEnabled="True" DockPanel.Dock="Top">
-                <TreeView Name="treeViewPresets" MouseDoubleClick="TreeViewPresetsMouseDoubleClick" KeyDown="TreeViewPresetsKeyDown" TabIndex="13" />
+            <GroupBox Header="Building presets - not loaded"
+                      Name="GroupBoxPresets"
+                      IsEnabled="True"
+                      DockPanel.Dock="Top">
+                <TreeView Name="treeViewPresets"
+                          MouseDoubleClick="TreeViewPresetsMouseDoubleClick"
+                          KeyDown="TreeViewPresetsKeyDown"
+                          TabIndex="13" />
             </GroupBox>
         </DockPanel>
-        <StatusBar Grid.Row="2" Grid.ColumnSpan="3">
+        <StatusBar Grid.Row="2"
+                   Grid.ColumnSpan="3">
             <StatusBarItem Content="Mouse controls: left - place, select, move / right - stop placement, remove / both - move all / double click - copy / wheel - zoom / wheel-click - rotate." />
-            <StatusBarItem Name="StatusBarItemStatus" Content="Standard" Margin="10,0,0,0" />
-            <StatusBarItem Name="StatusBarItemClipboardStatus" Margin="10,0,0,0" HorizontalAlignment="Right" />
+            <StatusBarItem Name="StatusBarItemStatus"
+                           Content="Standard"
+                           Margin="10,0,0,0" />
+            <StatusBarItem Name="StatusBarItemClipboardStatus"
+                           Margin="10,0,0,0"
+                           HorizontalAlignment="Right" />
         </StatusBar>
     </Grid>
 </Window>

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -269,8 +269,8 @@ namespace AnnoDesigner
                 return;
             }
             // size
-            textBoxWidth.Text = obj.Size.Width.ToString();
-            textBoxHeight.Text = obj.Size.Height.ToString();
+            textBoxWidth.Value = (int)obj.Size.Width;
+            textBoxHeight.Value = (int)obj.Size.Height;
             // color
             colorPicker.SelectedColor = obj.Color;
             // label
@@ -287,7 +287,7 @@ namespace AnnoDesigner
                 comboBoxIcon.SelectedItem = _noIconItem;
             }
             // radius
-            textBoxRadius.Text = obj.Radius.ToString();
+            textBoxRadius.Value = obj.Radius;
             //InfluenceRadius
             textBoxInfluenceRange.Text = obj.InfluenceRange.ToString();
             // flags
@@ -327,11 +327,11 @@ namespace AnnoDesigner
             // parse user inputs and create new object
             AnnoObject obj = new AnnoObject
             {
-                Size = new Size(int.Parse(textBoxWidth.Text), int.Parse(textBoxHeight.Text)),
+                Size = new Size(textBoxWidth?.Value ?? 1, textBoxHeight?.Value ?? 1),
                 Color = colorPicker.SelectedColor.HasValue ? colorPicker.SelectedColor.Value : Colors.Red,
                 Label = IsChecked(checkBoxLabel) ? textBoxLabel.Text : "",
                 Icon = comboBoxIcon.SelectedItem == _noIconItem ? null : ((IconImage)comboBoxIcon.SelectedItem).Name,
-                Radius = string.IsNullOrEmpty(textBoxRadius.Text) ? 0 : double.Parse(textBoxRadius.Text, CultureInfo.InvariantCulture),
+                Radius = textBoxRadius?.Value ?? 0,
                 InfluenceRange = string.IsNullOrEmpty(textBoxInfluenceRange.Text) ? 0 : double.Parse(textBoxInfluenceRange.Text, CultureInfo.InvariantCulture),
                 Borderless = IsChecked(checkBoxBorderless),
                 Road = IsChecked(checkBoxRoad),


### PR DESCRIPTION
I added some DoubleUpDown/IntegerUpDown controls from the WPF Toolkit.
this adds an aditional way of entering values and also adds some validition to the input fileds.

Before you could enter "foo" for width, heigth or radius and there was a messagebox with "incorrect building config". Now there will be entered the default value when loosing focus.