### PR TITLE
retarget to use .NET Framework 4.7.2

### DIFF
--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -25,7 +25,6 @@ namespace AnnoDesigner
     public partial class AnnoCanvas : UserControl
     {
         #region Properties
-
         /// <summary>
         /// Contains all loaded icons as a mapping of name (the filename without extension) to loaded BitmapImage.
         /// </summary>
@@ -697,7 +696,7 @@ namespace AnnoDesigner
                 {
                     var textPoint = objRect.TopLeft;
                     var text = new FormattedText(obj.Label, Thread.CurrentThread.CurrentCulture, FlowDirection.LeftToRight,
-                                                 TYPEFACE, 12, Brushes.Black, null, TextFormattingMode.Display)
+                                                 TYPEFACE, 12, Brushes.Black, null, TextFormattingMode.Display, App.DpiScale.PixelsPerDip)
                     {
                         MaxTextWidth = objRect.Width,
                         MaxTextHeight = objRect.Height
@@ -1001,7 +1000,7 @@ namespace AnnoDesigner
             // render all the lines            
             var text = informationLines.ToString();
             var f = new FormattedText(text, Thread.CurrentThread.CurrentCulture, FlowDirection.LeftToRight,
-                                           TYPEFACE, 12, Brushes.Black, null, TextFormattingMode.Display)
+                                           TYPEFACE, 12, Brushes.Black, null, TextFormattingMode.Display, App.DpiScale.PixelsPerDip)
             {
                 MaxTextWidth = Constants.StatisticsMargin - 20,
                 MaxTextHeight = RenderSize.Height,

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AnnoDesigner</RootNamespace>
     <AssemblyName>AnnoDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -9,8 +9,7 @@ namespace AnnoDesigner
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
-    public partial class App
-        : Application
+    public partial class App : Application
     {
         public static string ExecutablePath
         {
@@ -58,6 +57,10 @@ namespace AnnoDesigner
             if (ex != null) LogErrorMessage(ex);
         }
 
+        /// <summary>
+        /// Writes an exception to the error log
+        /// </summary>
+        /// <param name="e"></param>
         private void LogErrorMessage(Exception e)
         {
             try
@@ -71,6 +74,12 @@ namespace AnnoDesigner
             }
         }
 
+        /// <summary>
+        /// Writes a message to the error log.
+        /// </summary>
+        /// <param name="heading">The value for the heading in the error log.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="stackTrace">The stack trace for the error.</param>
         public static void WriteToErrorLog(string heading, string message, string stackTrace)
         {
             try
@@ -82,5 +91,10 @@ namespace AnnoDesigner
                 //Don't rethrow.
             }
         }
+
+        /// <summary>
+        /// The DPI information for the current monitor.
+        /// </summary>
+        public static DpiScale DpiScale { get; set; } 
     }
 }

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -22,8 +22,7 @@ namespace AnnoDesigner
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow
-        : Window
+    public partial class MainWindow : Window
     {
         private readonly WebClient _webClient;
         private IconImage _noIconItem;
@@ -86,6 +85,7 @@ namespace AnnoDesigner
             annoCanvas.OnStatusMessageChanged += StatusMessageChanged;
             annoCanvas.OnLoadedFileChanged += LoadedFileChanged;
             annoCanvas.OnClipboardChanged += ClipboardChanged;
+            DpiChanged += MainWindow_DpiChanged;
 
             //Get a reference an instance of Localization.MainWindow, so we can call UpdateLanguage() in the SelectedLanguage setter
             DependencyObject dependencyObject = LogicalTreeHelper.FindLogicalNode(this, "Menu");
@@ -386,6 +386,11 @@ namespace AnnoDesigner
         #endregion
 
         #region UI events
+        private void MainWindow_DpiChanged(object sender, DpiChangedEventArgs e)
+        {
+            App.DpiScale = e.NewDpi;
+            //TODO: Redraw statistics when change is merged.
+        }
 
         private void MenuItemCloseClick(object sender, RoutedEventArgs e)
         {

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -76,6 +76,9 @@ namespace AnnoDesigner
         public MainWindow()
         {
             InitializeComponent();
+
+            App.DpiScale = VisualTreeHelper.GetDpi(this);
+
             _instance = this;
             // initialize web client
             _webClient = new WebClient();

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -8,7 +8,7 @@
         <section name="AnnoDesigner.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
     </sectionGroup>
 </configSections>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup><userSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup><userSettings>
         <AnnoDesigner.Properties.Settings>
             <setting name="MainWindowTop" serializeAs="String">
                 <value>0</value>

--- a/PresetParser/PresetParser.csproj
+++ b/PresetParser/PresetParser.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PresetParser</RootNamespace>
     <AssemblyName>PresetParser</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/PresetParser/app.config
+++ b/PresetParser/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
Since .NET Framework 4.7.2 is available via Windows Update this should not trigger any installation on customer side.
Doing so enables the app to take advantage of some fixes/enhancements on High DPI displays.

Targeting .NET 4.8 would require Visual Studio 2019 on developer side. I think targeting .NET 4.7.2 should still allow Visual Studio back to 2015. Not sure about that, but definitely Visual studio 2017.
And for VS >=2017 there is a free Community edition.
[Can I use Visual Studio 2015 to target .net framework 4.7](https://stackoverflow.com/a/43420229)

[.NET Framework 4.7.2 is available on Windows Update, WSUS and MU Catalog](https://devblogs.microsoft.com/dotnet/net-framework-4-7-2-is-available-on-windows-update-wsus-and-mu-catalog/)
[Lifecycle FAQ—.NET Framework](https://support.microsoft.com/en-hk/help/17455/lifecycle-faq-net-framework)