### PR TITLE
Presets search null reference exception fix

### DIFF
--- a/AnnoDesigner/Localization.cs
+++ b/AnnoDesigner/Localization.cs
@@ -72,6 +72,7 @@ namespace AnnoDesigner.Localization
                         { "Borderless" , "Borderless" },
                         { "Road" , "Road" },
                         { "PlaceBuilding" , "Place building" },
+                        { "Search", "Search" },
                         { "TitleAbout" , "About" },
                         { "Title" , "Modified" },
                         { "BuildingLayoutDesigner" , "A building layout designer for Ubisofts Anno-series" },
@@ -148,6 +149,7 @@ namespace AnnoDesigner.Localization
                         { "Borderless" , "Randlos" },
                         { "Road" , "Straße" },
                         { "PlaceBuilding" , "Gebäude platzieren" },
+                        { "Search", "Suche" },
                         { "TitleAbout" , "über" },
                         { "Title" , "überarbeiteter" },
                         { "BuildingLayoutDesigner" , "Ein Gebäudelayout Designer für Ubisofts Anno Reihe" },
@@ -224,6 +226,7 @@ namespace AnnoDesigner.Localization
                         { "Borderless" , "Bez obramowania" },
                         { "Road" , "Droga / Ulica" },
                         { "PlaceBuilding" , "Postaw budynek" },
+                        { "Search", "Wyszukiwanie" },
                         { "TitleAbout" , "Na temat / O" },
                         { "Title" , "zmodyfikowany" },
                         { "BuildingLayoutDesigner" , "Program do planowania zabudowy w serii Anno Ubisoftu" },
@@ -300,6 +303,7 @@ namespace AnnoDesigner.Localization
                         { "Borderless" , "Без полей" },
                         { "Road" , "Дорогa" },
                         { "PlaceBuilding" , "Выбрать здание" },
+                        { "Search" , "Поиск" },
                         { "TitleAbout" , "О программе" },
                         { "Title" , "обновлено" },
                         { "BuildingLayoutDesigner" , "Конструктор макета здания для Ubisofts Anno-серии" },
@@ -702,6 +706,7 @@ namespace AnnoDesigner.Localization
             Borderless = Localization.Translations[language]["Borderless"];
             Road = Localization.Translations[language]["Road"];
             PlaceBuilding = Localization.Translations[language]["PlaceBuilding"];
+            Search = Localization.Translations[language]["Search"];
 
             //Status Bar
             StatusBarControls = Localization.Translations[language]["StatusBarControls"];
@@ -1149,6 +1154,15 @@ namespace AnnoDesigner.Localization
             set
             {
                 UpdateProperty(ref _placeBuilding, value);
+            }
+        }
+        private string _search;
+        public string Search
+        {
+            get { return _search; }
+            set
+            {
+                UpdateProperty(ref _search, value);
             }
         }
 

--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -361,7 +361,8 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="Search:"
+            <GroupBox Header="{Binding Path=Search}" 
+                      HeaderStringFormat=" {0}:"
                       Name="GroupBoxSearchPresets"
                       IsEnabled="True"
                       Height="Auto"

--- a/AnnoDesigner/TreeViewExtensions.cs
+++ b/AnnoDesigner/TreeViewExtensions.cs
@@ -150,7 +150,7 @@ namespace AnnoDesigner
             item.IsExpanded = true;
             if (item.Parent is TreeViewItem treeViewItem)
             {
-                return ExpandAncestors(treeViewItem, previousExpansionState);
+                return ExpandAncestorsToRoot(treeViewItem, previousExpansionState);
             }
             return previousExpansionState;
         }

--- a/AnnoDesigner/TreeViewSearch.cs
+++ b/AnnoDesigner/TreeViewSearch.cs
@@ -111,10 +111,6 @@ namespace AnnoDesigner
         /// <returns></returns>
         private bool Search(TreeViewItem item, string token, bool foundMatch)
         {
-            if (item.Header.ToString().Contains(token))
-            {
-                foundMatch = true;
-            }
             foreach (var node in item.Items)
             {
                 if (node is TreeViewItem treeViewItem)

--- a/AnnoDesigner/TreeViewSearch.cs
+++ b/AnnoDesigner/TreeViewSearch.cs
@@ -263,6 +263,7 @@ namespace AnnoDesigner
         /// <param name="treeViewItem"></param>
         private void GenerateItemContainers(TreeViewItem treeViewItem)
         {
+            Debug.WriteLine("Generating ItemContainer for: " + treeViewItem.ToString());
             var expandedState = treeViewItem.IsExpanded;
             treeViewItem.IsExpanded = true;
             var previousStates = treeViewItem.ExpandAncestors(new List<KeyValuePair<TreeViewItem, bool>>());


### PR DESCRIPTION
* Fix the for the null reference exception when switching languages (bug in ExpandAncestors).
* Localised the "Search" string
* Fixed some inconsistencies with the search results as they were displaying branches that matched the search token, which resulted in empty branches in the result