### PR TITLE
if window is minimised when closing, set to WindowState.Normal

### DIFF
--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -779,6 +779,10 @@ namespace AnnoDesigner
         {
             Settings.Default.TreeViewState = treeViewPresets.GetTreeViewState();
             Settings.Default.TreeViewSearchText = _mainWindowLocalization.TreeViewSearchText;
+            if (WindowState == WindowState.Minimized)
+            {
+                WindowState = WindowState.Normal;
+            }
             Settings.Default.Save();
         }
 


### PR DESCRIPTION
This caused an issue in 8.2 for a user, where they had closed the window while it was minimised. 

This meant the RenderSize.Height property was set to 0, so when `OnRender` ran (it runs once when the window starts minimised), the stats panel failed to draw, as `RenderSize.Height` was 0, which was an invalid value for the `MaxTextHeight` property of `FormattedText`.

This isn't an issue in the new release, but it should be safer to add this. It also doesn't make any sense for the window to start minimised anyway.