### PR TITLE
Made Failsafe for missing TreeView Translation and Preset Translation

### DIFF
--- a/AnnoDesigner/Presets/BuildingInfo.cs
+++ b/AnnoDesigner/Presets/BuildingInfo.cs
@@ -94,9 +94,12 @@ namespace AnnoDesigner.Presets
 
         public AnnoObject ToAnnoObject()
         {
+            var labelLocalization = Localization == null ? Identifier : Localization[AnnoDesigner.Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage)];
+            if (string.IsNullOrEmpty(labelLocalization)) { labelLocalization = Localization["eng"]; }
             return new AnnoObject
             {
-                Label = (Localization == null ? Identifier : Localization[AnnoDesigner.Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage)]),
+                //Label = (Localization == null ? Identifier : Localization[AnnoDesigner.Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage)]),
+                Label = labelLocalization,
                 Icon = IconFileName,
                 Radius = InfluenceRadius,
                 InfluenceRange = InfluenceRange,
@@ -109,7 +112,10 @@ namespace AnnoDesigner.Presets
 
         public string GetOrderParameter()
         {
-            return Localization == null ? Identifier : Localization[AnnoDesigner.Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage)];
+            var labelLocalization = Localization == null ? Identifier : Localization[AnnoDesigner.Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage)];
+            if (string.IsNullOrEmpty(labelLocalization)) { labelLocalization = Localization["eng"]; }
+            //return Localization == null ? Identifier : Localization[AnnoDesigner.Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage)];
+            return labelLocalization;
         }
     }
 

--- a/AnnoDesigner/TreeLocalization.cs
+++ b/AnnoDesigner/TreeLocalization.cs
@@ -388,7 +388,7 @@ namespace AnnoDesigner.TreeLocalization
                         { "Shipyards" , "Судоремонтные заводы" },
                         { "SpecialBuildings" , "Специальные здания" },
                         { "MiningBuildings" , "Горнодобывающие здания" },
-                        { "OrnamentalBuilding" , "Орнаменты" }
+                        {"OrnamentalBuilding" , "Орнаменты" }
                     }
                     },
             };
@@ -405,8 +405,16 @@ namespace AnnoDesigner.TreeLocalization
                 }
                 else
                 {
-                    Debug.WriteLine($"found no localization ({language}) for: \"{localizationHeader}\"");
-                    return localizationHeader;
+                    Debug.WriteLine($"try to set localization to english for: : \"{localizationHeader}\"");
+                    if (TreeLocalization.Translations["eng"].TryGetValue(localizationHeader.Replace(" ", String.Empty), out string engLocalization))
+                    {
+                        return engLocalization;
+                    }
+                    else
+                    {
+                        Debug.WriteLine($"found no localization (\"eng\") and ({language}) for : \"{localizationHeader}\"");
+                        return localizationHeader;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
If translation(s) is not found in ether Treeview translation or in the preset file, the tree or object will be translated in English