### PR TITLE
migrate settings on app update

### DIFF
--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -121,6 +121,13 @@ namespace AnnoDesigner
                     }
                 }
 
+                if (AnnoDesigner.Properties.Settings.Default.SettingsUpgradeNeeded)
+                {
+                    AnnoDesigner.Properties.Settings.Default.Upgrade();
+                    AnnoDesigner.Properties.Settings.Default.SettingsUpgradeNeeded = false;
+                    AnnoDesigner.Properties.Settings.Default.Save();
+                }
+
                 //var updateWindow = new UpdateWindow();
                 await Commons.Instance.UpdateHelper.ReplaceUpdatedPresetFileAsync();
 

--- a/AnnoDesigner/Properties/Settings.Designer.cs
+++ b/AnnoDesigner/Properties/Settings.Designer.cs
@@ -258,5 +258,17 @@ namespace AnnoDesigner.Properties {
                 this["TreeViewSearchText"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool SettingsUpgradeNeeded {
+            get {
+                return ((bool)(this["SettingsUpgradeNeeded"]));
+            }
+            set {
+                this["SettingsUpgradeNeeded"] = value;
+            }
+        }
     }
 }

--- a/AnnoDesigner/Properties/Settings.settings
+++ b/AnnoDesigner/Properties/Settings.settings
@@ -62,5 +62,8 @@
     <Setting Name="TreeViewSearchText" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="SettingsUpgradeNeeded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -67,6 +67,9 @@
             <setting name="TreeViewSearchText" serializeAs="String">
                 <value />
             </setting>
+            <setting name="SettingsUpgradeNeeded" serializeAs="String">
+                <value>True</value>
+            </setting>
         </AnnoDesigner.Properties.Settings>
     </userSettings>
     <applicationSettings>


### PR DESCRIPTION
This PR checks if the settings need an upgrade and migrate the settings from the old version.

The user doesn't need to select the language on every app update. 🎉 (at least that bothered me)