### PR TITLE
fix for missing icons when loading old layouts (created with old presets)

### DIFF
--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -1010,7 +1010,7 @@ namespace AnnoDesigner
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
-                var icons = new Dictionary<string, IconImage>();
+                var icons = new Dictionary<string, IconImage>(StringComparer.OrdinalIgnoreCase);
                 foreach (var curIcon in annoCanvas.Icons)
                 {
                     icons.Add(curIcon.Key, new IconImage(curIcon.Value.Name, curIcon.Value.Localizations, curIcon.Value.IconPath));

--- a/AnnoDesigner/PresetsLoader/IconLoader.cs
+++ b/AnnoDesigner/PresetsLoader/IconLoader.cs
@@ -49,7 +49,7 @@ namespace AnnoDesigner.PresetsLoader
                 }
 
                 // sort icons by their DisplayName
-                result = result.OrderBy(x => x.Value.DisplayName).ToDictionary(x => x.Key, x => x.Value);
+                result = result.OrderBy(x => x.Value.DisplayName).ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);//make sure ContainsKey is caseInSensitive
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When I created a layout with version 8.2 and presets 3.1.1 and then tried to load it in the current development version some icons were missing.
For example in my test the layout contained an icon "A7_**w**arehouse" and the app just knows of "A7_**W**arehouse". So just a simple mismatch in case.

The reason is (in `AnnoCanvas.RenderObject`):
```csharp
if (iconName != null && Icons.ContainsKey(iconName))
```
`Icons`is a `Dictionary<string, IconImage>` and by default the `ContainsKey` method is caseSensitive.
So to fix this the dictionary is created with a different default comparer.