### PR TITLE
fix flicker in statistics view

### DIFF
--- a/AnnoDesigner/viewmodel/StatisticsViewModel.cs
+++ b/AnnoDesigner/viewmodel/StatisticsViewModel.cs
@@ -235,6 +235,7 @@ namespace AnnoDesigner.viewmodel
             }
 
             var language = Localization.Localization.GetLanguageCodeFromName(MainWindow.SelectedLanguage);
+            var tempList = new List<StatisticsBuilding>();
 
             foreach (var item in groupedBuildingsByIdentifier
                         .Where(_ => !_.ElementAt(0).Road && _.ElementAt(0).Identifier != null)
@@ -272,7 +273,12 @@ namespace AnnoDesigner.viewmodel
                     statisticBuilding.Name = TextNameNotFound;
                 }
 
-                result.Add(statisticBuilding);
+                tempList.Add(statisticBuilding);
+            }
+
+            foreach (var curBuilding in tempList.OrderByDescending(x => x.Count).ThenBy(x => x.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                result.Add(curBuilding);
             }
 
             return result;


### PR DESCRIPTION
This PR fixes "flicker" (don't know how to name it) in the statistics view.
Actually there was no explicit sort of the buildings, but now there is.

See images for explanation:
- before

![statistics_before](https://user-images.githubusercontent.com/6222752/58307679-c2369400-7dff-11e9-8369-5b6c692c6e5e.gif)
- after

![statistics_after](https://user-images.githubusercontent.com/6222752/58307680-c4005780-7dff-11e9-9cf0-a96df64bcdc6.gif)