### PR TITLE
fix predefined color

### DIFF
--- a/AnnoDesigner.Core/Presets/Helper/ColorPresetsHelper.cs
+++ b/AnnoDesigner.Core/Presets/Helper/ColorPresetsHelper.cs
@@ -85,6 +85,12 @@ namespace AnnoDesigner.Core.Presets.Helper
             {
                 result = colorForTemplateContainingIdentifier.Color;
             }
+            //specific color for template but without identifier defined?
+            else if (colorsForTemplate.FirstOrDefault(x => x.TargetIdentifiers.Count == 0) != null)
+            {
+                result = colorsForTemplate.FirstOrDefault(x => x.TargetIdentifiers.Count == 0).Color;
+            }
+            //use first found defined color
             else
             {
                 result = colorsForTemplate.First().Color;


### PR DESCRIPTION
Fix wrong color when there is a predefined color without identifiers before a color with identifiers.
Reported by @StingMcRay via discord:
![color_unknown](https://user-images.githubusercontent.com/6222752/58433324-01dad580-80b7-11e9-9fc2-25429e857b0b.png)
