### PR TITLE
Add import/export from/to JSON string

### DIFF
--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -247,7 +247,7 @@ namespace AnnoDesigner
             {
                 return _loadedFile;
             }
-            private set
+            set
             {
                 if (_loadedFile != value)
                 {

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -50,6 +50,9 @@
     <Compile Include="BuildingPresetsExtensions.cs" />
     <Compile Include="ColorHueSaturationBrightnessComparer.cs" />
     <Compile Include="Commons.cs" />
+    <Compile Include="InputWindow.xaml.cs">
+      <DependentUpon>InputWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="model\ICommons.cs" />
     <Compile Include="model\IUpdateHelper.cs" />
     <Compile Include="model\BuildingInfluenceType.cs" />
@@ -85,6 +88,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="AnnoCanvas.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="InputWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/AnnoDesigner/InputWindow.xaml
+++ b/AnnoDesigner/InputWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:l="clr-namespace:AnnoDesigner.Localization"
         xmlns:local="clr-namespace:AnnoDesigner"
         mc:Ignorable="d"
         Title="InputWindow"
@@ -13,25 +14,37 @@
         MaxWidth="600"
         WindowStyle="SingleBorderWindow"
         ResizeMode="CanMinimize">
+    <Window.Resources>
+        <l:MainWindow x:Key="localization"></l:MainWindow>
+    </Window.Resources>
+    <Window.DataContext>
+        <Binding Source="{StaticResource localization}"></Binding>
+    </Window.DataContext>
     <StackPanel Margin="5,5,5,5">
         <TextBlock x:Name="message"
                    Text="The message"
                    Margin="0,0,0,10" />
         <TextBox x:Name="input"
-                 Padding="3,3,3,3" />
+                 Padding="3,3,3,3"
+                 AcceptsReturn="True"
+                 FontFamily="Arial"
+                 FontSize="14"
+                 MaxHeight="300"
+                 TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto" />
         <Grid Margin="0,10,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Button x:Name="OkButton"
-                    Content="OK"
+                    Content="{Binding Ok}"
                     Grid.Column="0"
                     Margin="0,0,5,0"
                     Padding="8"
                     Click="OkButton_Click" />
             <Button x:Name="CancelButton"
-                    Content="Cancel"
+                    Content="{Binding Cancel}"
                     Grid.Column="1"
                     Margin="5,0,0,0"
                     Padding="8"

--- a/AnnoDesigner/InputWindow.xaml
+++ b/AnnoDesigner/InputWindow.xaml
@@ -1,0 +1,41 @@
+﻿<Window x:Class="AnnoDesigner.InputWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AnnoDesigner"
+        mc:Ignorable="d"
+        Title="InputWindow"
+        WindowStartupLocation="CenterScreen"
+        SizeToContent="WidthAndHeight"
+        MinWidth="500"
+        MinHeight="100"
+        MaxWidth="600"
+        WindowStyle="SingleBorderWindow"
+        ResizeMode="CanMinimize">
+    <StackPanel Margin="5,5,5,5">
+        <TextBlock x:Name="message"
+                   Text="The message"
+                   Margin="0,0,0,10" />
+        <TextBox x:Name="input"
+                 Padding="3,3,3,3" />
+        <Grid Margin="0,10,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button x:Name="OkButton"
+                    Content="OK"
+                    Grid.Column="0"
+                    Margin="0,0,5,0"
+                    Padding="8"
+                    Click="OkButton_Click" />
+            <Button x:Name="CancelButton"
+                    Content="Cancel"
+                    Grid.Column="1"
+                    Margin="5,0,0,0"
+                    Padding="8"
+                    Click="CancelButton_Click" />
+        </Grid>
+    </StackPanel>
+</Window>

--- a/AnnoDesigner/InputWindow.xaml.cs
+++ b/AnnoDesigner/InputWindow.xaml.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace AnnoDesigner
+{
+    /// <summary>
+    /// Interaction logic for InputWindow.xaml
+    /// </summary>
+    public partial class InputWindow : Window
+    {
+        public InputWindow()
+        {
+            InitializeComponent();
+        }
+
+        public InputWindow(string message, string title, string defaultValue = "")
+        {
+            InitializeComponent();
+
+            Loaded += new RoutedEventHandler(InputWindow_Loaded);
+
+            this.message.Text = message;
+            Title = title;
+            input.Text = defaultValue;
+        }
+
+        private void InputWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            input.Focus();
+        }
+
+        public static string Prompt(string message, string title, string defaultValue = "")
+        {
+            var inputWindow = new InputWindow(message, title, defaultValue);
+            inputWindow.ShowDialog();
+
+            if (inputWindow.DialogResult == true)
+            {
+                return inputWindow.ResponseText;
+            }
+
+            return null;
+        }
+
+        public string ResponseText
+        {
+            get { return input.Text; }
+        }
+
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/AnnoDesigner/Localization.cs
+++ b/AnnoDesigner/Localization.cs
@@ -30,6 +30,7 @@ namespace AnnoDesigner.Localization
                         { "Open" , "Open" },
                         { "Save" , "Save" },
                         { "SaveAs" , "Save As" },
+                        { "CopyLayoutToClipboard" , "Copy layout to clipboard as JSON" },
                         { "Exit" , "Exit" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Normalize" },
@@ -134,6 +135,7 @@ namespace AnnoDesigner.Localization
                         { "Open" , "Öffnen" },
                         { "Save" , "Speichern" },
                         { "SaveAs" , "Speichern unter" },
+                        { "CopyLayoutToClipboard" , "Layout als JSON in die Zwischenablage kopieren" },
                         { "Exit" , "Beenden" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Normalisieren" },
@@ -238,6 +240,7 @@ namespace AnnoDesigner.Localization
                         { "Open" , "Ouvrir" },
                         { "Save" , "Sauvegarder" },
                         { "SaveAs" , "Sauvegarder sous" },
+                        { "CopyLayoutToClipboard" , "Copier la mise en page dans le presse-papiers en tant que JSON" },
                         { "Exit" , "Quitter" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Centrer" },
@@ -343,6 +346,7 @@ namespace AnnoDesigner.Localization
                         { "Save" , "Zapisz" },
                         { "SaveAs" , "Zapisz jako" },
                         { "Exit" , "Zamknij" },
+                        { "CopyLayoutToClipboard" , "Skopiuj układ do schowka jako JSON" },
                         { "Extras" , "Dodatki" },
                         { "Normalize" , "Znormalizuj" },
                         { "ResetZoom" , "Resetuj powiększenie" },
@@ -446,6 +450,7 @@ namespace AnnoDesigner.Localization
                         { "Open" , "Открыть" },
                         { "Save" , "Сохранить" },
                         { "SaveAs" , "Сохранить как" },
+                        { "CopyLayoutToClipboard" , "Скопировать макет в буфер обмена как JSON" },
                         { "Exit" , "Выход" },
                         { "Extras" , "Дополнительно" },
                         { "Normalize" , "Нормализация" },
@@ -852,6 +857,7 @@ namespace AnnoDesigner.Localization
             Open = Localization.Translations[language]["Open"];
             Save = Localization.Translations[language]["Save"];
             SaveAs = Localization.Translations[language]["SaveAs"];
+            CopyLayoutToClipboard = Localization.Translations[language]["CopyLayoutToClipboard"];
             Exit = Localization.Translations[language]["Exit"];
 
             //Extras Menu
@@ -903,7 +909,7 @@ namespace AnnoDesigner.Localization
             BuildingSettingsViewModel.TextDistance = Localization.Translations[language]["Distance"];
             Both = Localization.Translations[language]["Both"];
             BuildingSettingsViewModel.TextPavedStreet = Localization.Translations[language]["PavedStreet"];
-            BuildingSettingsViewModel.TextPavedStreetWarningTitle = Localization.Translations[language]["PavedStreetWarningTitle"];      
+            BuildingSettingsViewModel.TextPavedStreetWarningTitle = Localization.Translations[language]["PavedStreetWarningTitle"];
             BuildingSettingsViewModel.TextPavedStreetToolTip = Localization.Translations[language]["PavedStreetToolTip"];
             BuildingSettingsViewModel.TextOptions = Localization.Translations[language]["Options"];
             BuildingSettingsViewModel.TextEnableLabel = Localization.Translations[language]["EnableLabel"];
@@ -950,6 +956,7 @@ namespace AnnoDesigner.Localization
                 UpdateProperty(ref _file, value);
             }
         }
+
         private string _newCanvas;
         public string NewCanvas
         {
@@ -959,6 +966,7 @@ namespace AnnoDesigner.Localization
                 UpdateProperty(ref _newCanvas, value);
             }
         }
+
         private string _open;
         public string Open
         {
@@ -968,6 +976,7 @@ namespace AnnoDesigner.Localization
                 UpdateProperty(ref _open, value);
             }
         }
+
         private string _save;
         public string Save
         {
@@ -977,6 +986,7 @@ namespace AnnoDesigner.Localization
                 UpdateProperty(ref _save, value);
             }
         }
+
         private string _saveAs;
         public string SaveAs
         {
@@ -986,6 +996,17 @@ namespace AnnoDesigner.Localization
                 UpdateProperty(ref _saveAs, value);
             }
         }
+
+        private string _copyLayoutToClipboard;
+        public string CopyLayoutToClipboard
+        {
+            get { return _copyLayoutToClipboard; }
+            set
+            {
+                UpdateProperty(ref _copyLayoutToClipboard, value);
+            }
+        }
+
         private string _exit;
         public string Exit
         {

--- a/AnnoDesigner/Localization.cs
+++ b/AnnoDesigner/Localization.cs
@@ -31,7 +31,7 @@ namespace AnnoDesigner.Localization
                         { "Save" , "Save" },
                         { "SaveAs" , "Save As" },
                         { "CopyLayoutToClipboard" , "Copy layout to clipboard as JSON" },
-                        //LoadLayoutFromJson
+                        { "LoadLayoutFromJson" , "Load layout from JSON" },
                         { "Exit" , "Exit" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Normalize" },
@@ -126,7 +126,12 @@ namespace AnnoDesigner.Localization
                         { "UpdateErrorPresetMessage" , "There was an error installing the update." },
                         { "ColorsInLayout" , "Colors in Layout" },
                         { "ColorsInLayoutToolTip" , "Double click color to select it" },
-                        { "UpdateNoConnectionMessage" , "Could not establish a connection to the internet." }
+                        { "UpdateNoConnectionMessage" , "Could not establish a connection to the internet." },
+                        { "LoadLayoutHeader" , "Load Layout" },
+                        { "LoadLayoutMessage" , "Please paste the JSON string below." },
+                        { "ClipboardContainsLayoutAsJson" , "Clipboard contains current layout as JSON." },
+                        { "OK" , "OK" },
+                        { "Cancel" , "Cancel" },
                     }
                 },
                 {
@@ -137,6 +142,7 @@ namespace AnnoDesigner.Localization
                         { "Save" , "Speichern" },
                         { "SaveAs" , "Speichern unter" },
                         { "CopyLayoutToClipboard" , "Layout als JSON in die Zwischenablage kopieren" },
+                        { "LoadLayoutFromJson" , "Layout aus JSON laden" },
                         { "Exit" , "Beenden" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Normalisieren" },
@@ -231,7 +237,12 @@ namespace AnnoDesigner.Localization
                         { "UpdateErrorPresetMessage" , "Es gab einen Fehler bei der Installation des Updates." },
                         { "ColorsInLayout" , "Farben im Layout" },
                         { "ColorsInLayoutToolTip" , "Doppelklicken Sie auf die Farbe, um sie auszuwählen." },
-                        { "UpdateNoConnectionMessage" , "Es konnte keine Verbindung zum Internet hergestellt werden." }
+                        { "UpdateNoConnectionMessage" , "Es konnte keine Verbindung zum Internet hergestellt werden." },
+                        { "LoadLayoutHeader" , "Layout laden" },
+                        { "LoadLayoutMessage" , "Bitte fügen Sie die JSON-Zeichenkette unten ein." },
+                        { "ClipboardContainsLayoutAsJson" , "Die Zwischenablage enthält das aktuelle Layout als JSON." },
+                        { "OK" , "OK" },
+                        { "Cancel" , "Abbrechen" },
                     }
                 },
                 {
@@ -242,6 +253,7 @@ namespace AnnoDesigner.Localization
                         { "Save" , "Sauvegarder" },
                         { "SaveAs" , "Sauvegarder sous" },
                         { "CopyLayoutToClipboard" , "Copier la mise en page dans le presse-papiers en tant que JSON" },
+                        { "LoadLayoutFromJson" , "Charger l'agencement à partir de JSON" },
                         { "Exit" , "Quitter" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Centrer" },
@@ -336,7 +348,12 @@ namespace AnnoDesigner.Localization
                         { "UpdateErrorPresetMessage" , "Il y a eu une erreur lors de l'installation de la mise à jour." },
                         { "ColorsInLayout" , "Couleurs dans la mise en page" },
                         { "ColorsInLayoutToolTip" , "Double-cliquez sur la couleur pour la sélectionner" },
-                        { "UpdateNoConnectionMessage" , "Impossible d'établir une connexion à Internet." }
+                        { "UpdateNoConnectionMessage" , "Impossible d'établir une connexion à Internet." },
+                        { "LoadLayoutHeader" , "Disposition de la charge" },
+                        { "LoadLayoutMessage" , "Veuillez coller la chaîne JSON ci-dessous." },
+                        { "ClipboardContainsLayoutAsJson" , "Le presse-papiers contient la mise en page actuelle en tant que JSON." },
+                        { "OK" , "OK" },
+                        { "Cancel" , "Annuler" },
                     }
                 },
                 {
@@ -348,6 +365,7 @@ namespace AnnoDesigner.Localization
                         { "SaveAs" , "Zapisz jako" },
                         { "Exit" , "Zamknij" },
                         { "CopyLayoutToClipboard" , "Skopiuj układ do schowka jako JSON" },
+                        { "LoadLayoutFromJson" , "Układ obciążenia od JSON" },
                         { "Extras" , "Dodatki" },
                         { "Normalize" , "Znormalizuj" },
                         { "ResetZoom" , "Resetuj powiększenie" },
@@ -441,7 +459,12 @@ namespace AnnoDesigner.Localization
                         { "UpdateErrorPresetMessage" , "Wystąpił błąd podczas instalacji aktualizacji." },
                         { "ColorsInLayout" , "Kolory w układzie" },
                         { "ColorsInLayoutToolTip" , "Podwójne kliknięcie na kolor, aby go wybrać" },
-                        { "UpdateNoConnectionMessage" , "Nie udało się nawiązać połączenia z Internetem." }
+                        { "UpdateNoConnectionMessage" , "Nie udało się nawiązać połączenia z Internetem." },
+                        { "LoadLayoutHeader" , "Układ obciążenia" },
+                        { "LoadLayoutMessage" , "Proszę wkleić poniższy ciąg JSON." },
+                        { "ClipboardContainsLayoutAsJson" , "Schowek zawiera aktualny układ jako JSON." },
+                        { "OK" , "OK" },
+                        { "Cancel" , "Odwołaj" },
                     }
                 },
                 {
@@ -452,6 +475,7 @@ namespace AnnoDesigner.Localization
                         { "Save" , "Сохранить" },
                         { "SaveAs" , "Сохранить как" },
                         { "CopyLayoutToClipboard" , "Скопировать макет в буфер обмена как JSON" },
+                        { "LoadLayoutFromJson" , "Схема загрузки от JSON" },
                         { "Exit" , "Выход" },
                         { "Extras" , "Дополнительно" },
                         { "Normalize" , "Нормализация" },
@@ -546,7 +570,12 @@ namespace AnnoDesigner.Localization
                         { "UpdateErrorPresetMessage" , "Произошла ошибка при установке обновления." },
                         { "ColorsInLayout" , "Цвета в макетах" },
                         { "ColorsInLayoutToolTip" , "Дважды щелкните по цвету, чтобы выбрать его." },
-                        { "UpdateNoConnectionMessage" , "Не смог установить соединение с интернетом." }
+                        { "UpdateNoConnectionMessage" , "Не смог установить соединение с интернетом." },
+                        { "LoadLayoutHeader" , "Загрузить макет" },
+                        { "LoadLayoutMessage" , "Пожалуйста, вставьте JSON строку ниже." },
+                        { "ClipboardContainsLayoutAsJson" , "Буфер обмена содержит текущую верстку в виде JSON." },
+                        { "OK" , "OK" },
+                        { "Cancel" , "Отмена" },
                     }
                 },
             };
@@ -852,6 +881,9 @@ namespace AnnoDesigner.Localization
             StatisticsViewModel.TextTiles = Localization.Translations[language]["StatTiles"];
             StatisticsViewModel.TextNameNotFound = Localization.Translations[language]["StatNameNotFound"];
 
+            Ok = Localization.Translations[language]["OK"];
+            Cancel = Localization.Translations[language]["Cancel"];
+
             //File Menu
             File = Localization.Translations[language]["File"];
             NewCanvas = Localization.Translations[language]["NewCanvas"];
@@ -859,7 +891,7 @@ namespace AnnoDesigner.Localization
             Save = Localization.Translations[language]["Save"];
             SaveAs = Localization.Translations[language]["SaveAs"];
             CopyLayoutToClipboard = Localization.Translations[language]["CopyLayoutToClipboard"];
-            //LoadLayoutFromJson
+            LoadLayoutFromJson = Localization.Translations[language]["LoadLayoutFromJson"];
             Exit = Localization.Translations[language]["Exit"];
 
             //Extras Menu
@@ -1006,6 +1038,36 @@ namespace AnnoDesigner.Localization
             set
             {
                 UpdateProperty(ref _copyLayoutToClipboard, value);
+            }
+        }
+
+        private string _loadLayoutFromJson;
+        public string LoadLayoutFromJson
+        {
+            get { return _loadLayoutFromJson; }
+            set
+            {
+                UpdateProperty(ref _loadLayoutFromJson, value);
+            }
+        }
+
+        private string _ok;
+        public string Ok
+        {
+            get { return _ok; }
+            set
+            {
+                UpdateProperty(ref _ok, value);
+            }
+        }
+
+        private string _cancel;
+        public string Cancel
+        {
+            get { return _cancel; }
+            set
+            {
+                UpdateProperty(ref _cancel, value);
             }
         }
 

--- a/AnnoDesigner/Localization.cs
+++ b/AnnoDesigner/Localization.cs
@@ -31,6 +31,7 @@ namespace AnnoDesigner.Localization
                         { "Save" , "Save" },
                         { "SaveAs" , "Save As" },
                         { "CopyLayoutToClipboard" , "Copy layout to clipboard as JSON" },
+                        //LoadLayoutFromJson
                         { "Exit" , "Exit" },
                         { "Extras" , "Extras" },
                         { "Normalize" , "Normalize" },
@@ -858,6 +859,7 @@ namespace AnnoDesigner.Localization
             Save = Localization.Translations[language]["Save"];
             SaveAs = Localization.Translations[language]["SaveAs"];
             CopyLayoutToClipboard = Localization.Translations[language]["CopyLayoutToClipboard"];
+            //LoadLayoutFromJson
             Exit = Localization.Translations[language]["Exit"];
 
             //Extras Menu

--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -98,8 +98,9 @@
                               CommandTarget="{Binding ElementName=annoCanvas}" />
                     <Separator />
                     <MenuItem Header="{Binding CopyLayoutToClipboard}"
-                              Click="MenuCopyLayoutToClipboardClick"
-                              Command="{Binding ElementName=mainWindow,Path=CopyLayoutToClipboardCommand}" />
+                              Click="MenuCopyLayoutToClipboardClick" />
+                    <MenuItem Header="{Binding LoadLayoutFromJson}"
+                              Click="MenuLoadLayoutFromJsonClick" />
                     <Separator />
                     <MenuItem Header="{Binding Path=Exit}"
                               Click="MenuItemCloseClick" />

--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -97,6 +97,10 @@
                               Command="ApplicationCommands.SaveAs"
                               CommandTarget="{Binding ElementName=annoCanvas}" />
                     <Separator />
+                    <MenuItem Header="{Binding CopyLayoutToClipboard}"
+                              Click="MenuCopyLayoutToClipboardClick"
+                              Command="{Binding ElementName=mainWindow,Path=CopyLayoutToClipboardCommand}" />
+                    <Separator />
                     <MenuItem Header="{Binding Path=Exit}"
                               Click="MenuItemCloseClick" />
                 </MenuItem>

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -1063,7 +1063,7 @@ namespace AnnoDesigner
 
                 string language = Localization.Localization.GetLanguageCodeFromName(SelectedLanguage);
 
-                MessageBox.Show("Clipboard contains current layout as JSON.",
+                MessageBox.Show(Localization.Localization.Translations[language]["ClipboardContainsLayoutAsJson"],
                     Localization.Localization.Translations[language]["Successful"],
                     MessageBoxButton.OK,
                     MessageBoxImage.Information,
@@ -1221,7 +1221,10 @@ namespace AnnoDesigner
 
         private void MenuLoadLayoutFromJsonClick(object sender, RoutedEventArgs e)
         {
-            var input = InputWindow.Prompt("Please paste the JSON string below.", "Load Layout");
+            string language = Localization.Localization.GetLanguageCodeFromName(SelectedLanguage);
+
+            var input = InputWindow.Prompt(Localization.Localization.Translations[language]["LoadLayoutMessage"],
+                Localization.Localization.Translations[language]["LoadLayoutHeader"]);
             if (!string.IsNullOrWhiteSpace(input))
             {
                 var jsonArray = Encoding.UTF8.GetBytes(input);

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -23,6 +23,9 @@ using AnnoDesigner.Core.Models;
 using AnnoDesigner.Core;
 using AnnoDesigner.Core.Presets.Models;
 using AnnoDesigner.Core.Presets.Helper;
+using AnnoDesigner.Core.Layout.Models;
+using AnnoDesigner.Core.Layout;
+using System.Text;
 
 namespace AnnoDesigner
 {
@@ -107,6 +110,7 @@ namespace AnnoDesigner
         }
 
         private readonly ICommons _commons;
+        private readonly ILayoutLoader _layoutLoader;
 
         #region Initialization
 
@@ -118,6 +122,7 @@ namespace AnnoDesigner
         public MainWindow(ICommons commonsToUse) : this()
         {
             _commons = commonsToUse;
+            _layoutLoader = new LayoutLoader();
 
             App.DpiScale = VisualTreeHelper.GetDpi(this);
 
@@ -823,6 +828,7 @@ namespace AnnoDesigner
 
             }
         }
+
         private void LanguageMenuSubmenuClosed(object sender, RoutedEventArgs e)
         {
             SelectedLanguageChanged();
@@ -1042,6 +1048,27 @@ namespace AnnoDesigner
                 WindowState = WindowState.Normal;
             }
             Settings.Default.Save();
+        }
+
+        private void MenuCopyLayoutToClipboardClick(object sender, RoutedEventArgs e)
+        {
+            using (var ms = new MemoryStream())
+            {
+                annoCanvas.Normalize(1);
+                _layoutLoader.SaveLayout(annoCanvas.PlacedObjects, ms);
+
+                var jsonString = Encoding.UTF8.GetString(ms.ToArray());
+
+                Clipboard.SetText(jsonString, TextDataFormat.UnicodeText);
+
+                string language = Localization.Localization.GetLanguageCodeFromName(SelectedLanguage);
+
+                MessageBox.Show("Clipboard contains current layout as JSON.",
+                    Localization.Localization.Translations[language]["Successful"],
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information,
+                    MessageBoxResult.OK);
+            }
         }
 
         /// <summary>

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -1218,5 +1218,27 @@ namespace AnnoDesigner
             thread.Start();
             thread.Join(TimeSpan.FromSeconds(10));
         }
+
+        private void MenuLoadLayoutFromJsonClick(object sender, RoutedEventArgs e)
+        {
+            var input = InputWindow.Prompt("Please paste the JSON string below.", "Load Layout");
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                var jsonArray = Encoding.UTF8.GetBytes(input);
+                using (var ms = new MemoryStream(jsonArray))
+                {
+                    var loadedLayout = _layoutLoader.LoadLayout(ms);
+
+                    if (loadedLayout != null)
+                    {
+                        annoCanvas.SelectedObjects.Clear();
+                        annoCanvas.PlacedObjects = loadedLayout;
+                        annoCanvas.Normalize(1);
+
+                        AnnoCanvas_StatisticsUpdated(this, EventArgs.Empty);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds the possibility to save the current layout as JSON to the clipboard and also to load a layout from a pasted JSON string.

This feature came up on discord to ad layout "files" to the provided layouts in the wiki.
![menu](https://user-images.githubusercontent.com/6222752/58759387-58b63400-8529-11e9-9546-8b4ecee4870e.png)
![input](https://user-images.githubusercontent.com/6222752/58759388-5a7ff780-8529-11e9-9a68-45c02adb0c98.png)
