### PR TITLE
raise only one event when language is changed

### DIFF
--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -131,13 +131,12 @@
                     <MenuItem Header="{Binding Path=RenderSelectionHighlightsOnExportedImage}"
                               IsCheckable="True"
                               IsChecked="False"
-                              Name="MenuItemExportSelection" />                    
+                              Name="MenuItemExportSelection" />
                 </MenuItem>
                 <MenuItem Name="LanguageMenu"
                           Header="{Binding Path=Language}"
                           TabIndex="23"
-                          Click="MenuItemLanguageClick"
-                          SubmenuClosed="LanguageMenuSubmenuClosed">
+                          Click="MenuItemLanguageClick">
                     <MenuItem Header="English"
                               IsCheckable="True"
                               IsChecked="True"

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -830,11 +830,6 @@ namespace AnnoDesigner
             }
         }
 
-        private void LanguageMenuSubmenuClosed(object sender, RoutedEventArgs e)
-        {
-            SelectedLanguageChanged();
-        }
-
         #endregion
 
         private void ComboxBoxInfluenceType_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
This PR fixes the issue, that the event to repopulate the tree is raised multiple times when the language is changed.