### PR TITLE
allow transparency on "Place Building"

### DIFF
--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -554,7 +554,7 @@ namespace AnnoDesigner
             //drawingContext.DrawRectangle(_lightBrush, _highlightPen, new Rect(GridToScreen(ScreenToGrid(_mousePosition)), new Size(_gridStep, _gridStep)));
 
             // draw placed objects
-            RenderObject(drawingContext, _placedObjects);
+            RenderObjectList(drawingContext, _placedObjects, useTransparency: false);
             RenderObjectInfluenceRadius(drawingContext, _selectedObjects);
             RenderObjectInfluenceRange(drawingContext, _selectedObjects);
             _selectedObjects.ForEach(_ => RenderObjectSelection(drawingContext, _));
@@ -579,9 +579,7 @@ namespace AnnoDesigner
                     // draw influence range
                     RenderObjectInfluenceRange(drawingContext, _currentObjects);
                     // draw with transparency
-                    CurrentObjects.ForEach(_ => _.Color = new SerializableColor(128, _.Color.R, _.Color.G, _.Color.B));
-                    RenderObject(drawingContext, CurrentObjects);
-                    CurrentObjects.ForEach(_ => _.Color = new SerializableColor(255, _.Color.R, _.Color.G, _.Color.B));
+                    RenderObjectList(drawingContext, CurrentObjects, useTransparency: true);
                 }
             }
 
@@ -652,17 +650,21 @@ namespace AnnoDesigner
         /// </summary>
         /// <param name="drawingContext">context used for rendering</param>
         /// <param name="obj">object to render</param>
-        private void RenderObject(DrawingContext drawingContext, List<AnnoObject> objects)
+        private void RenderObjectList(DrawingContext drawingContext, List<AnnoObject> objects, bool useTransparency)
         {
-
             foreach (var obj in objects)
             {
-
                 // draw object rectangle
                 var objRect = GetObjectScreenRect(obj);
-                var brush = new SolidColorBrush(obj.Color);
-                brush.Freeze();
 
+                var color = obj.Color.MediaColor;
+                if (useTransparency)
+                {
+                    color.A = 128;
+                }
+
+                var brush = new SolidColorBrush(color);
+                brush.Freeze();
 
                 if (obj.Borderless)
                 {

--- a/Tests/AnnoDesigner.Core.Tests/LayoutLoaderTests.cs
+++ b/Tests/AnnoDesigner.Core.Tests/LayoutLoaderTests.cs
@@ -138,6 +138,30 @@ namespace AnnoDesigner.Core.Tests
         }
 
         [Fact]
+        public void LoadLayout_LayoutHasBuildingWithTransparentColor_ShouldReturnListWithObjectAndTransparentColor()
+        {
+            // Arrange
+            ILayoutLoader loader = new LayoutLoader();
+
+            var expectedA = 92;
+            var expectedR = 0;
+            var expectedG = 242;
+            var expectedB = 63;
+            var layoutContent = $"{{\"FileVersion\":{CoreConstants.LayoutFileVersion},\"Objects\":[{{\"Identifier\":\"Lorem\",\"Color\":{{\"A\":{expectedA},\"R\":{expectedR},\"G\":{expectedG},\"B\":{expectedB}}}}}]}}";
+            var streamWithLayout = new MemoryStream(Encoding.UTF8.GetBytes(layoutContent));
+
+            // Act
+            var result = loader.LoadLayout(streamWithLayout, true);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal(expectedA, result[0].Color.A);
+            Assert.Equal(expectedR, result[0].Color.R);
+            Assert.Equal(expectedG, result[0].Color.G);
+            Assert.Equal(expectedB, result[0].Color.B);
+        }
+
+        [Fact]
         public void SaveLayout_LayoutHasOneObject_ShouldReturnListWithOneObject()
         {
             // Arrange
@@ -156,6 +180,36 @@ namespace AnnoDesigner.Core.Tests
 
             // Assert
             Assert.Single(result);
+        }
+
+        [Fact]
+        public void SaveLayout_LayoutHasBuildingWithTransparentColor_ShouldReturnListWithOneObjectAndTransparentColor()
+        {
+            // Arrange
+            ILayoutLoader loader = new LayoutLoader();
+
+            byte expectedA = 92;
+            byte expectedR = 0;
+            byte expectedG = 242;
+            byte expectedB = 63;
+
+            var savedStream = new MemoryStream();
+
+            var listToSave = new List<AnnoObject> { new AnnoObject { Identifier = "Lorem", Color = new SerializableColor(expectedA, expectedR, expectedG, expectedB) } };
+
+            // Act
+            loader.SaveLayout(listToSave, savedStream);
+
+            savedStream.Position = 0;
+
+            var result = loader.LoadLayout(savedStream);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal(expectedA, result[0].Color.A);
+            Assert.Equal(expectedR, result[0].Color.R);
+            Assert.Equal(expectedG, result[0].Color.G);
+            Assert.Equal(expectedB, result[0].Color.B);
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue when the user selected a color with transparency and use the "Place Building" button.

There are also tests to ensure load/save of layouts with transparent colors.