### PR TITLE
fix #122 (add proper solution for logging )

### DIFF
--- a/AnnoDesigner.Core/AnnoDesigner.Core.csproj
+++ b/AnnoDesigner.Core/AnnoDesigner.Core.csproj
@@ -81,6 +81,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helper\SerializationHelper.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="NLog">
+      <Version>4.6.7</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AnnoDesigner.Core/Presets/Loader/BuildingPresetsLoader.cs
+++ b/AnnoDesigner.Core/Presets/Loader/BuildingPresetsLoader.cs
@@ -7,11 +7,14 @@ using System.Text;
 using System.Threading.Tasks;
 using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.Presets.Models;
+using NLog;
 
 namespace AnnoDesigner.Core.Presets.Loader
 {
     public class BuildingPresetsLoader
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         public BuildingPresets Load(string pathToBuildingPresetsFile)
         {
             BuildingPresets result = null;
@@ -22,7 +25,7 @@ namespace AnnoDesigner.Core.Presets.Loader
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error loading the buildings.{Environment.NewLine}{ex}");
+                logger.Error(ex, "Error loading the buildings.");
                 throw;
             }
 

--- a/AnnoDesigner.Core/Presets/Loader/ColorPresetsLoader.cs
+++ b/AnnoDesigner.Core/Presets/Loader/ColorPresetsLoader.cs
@@ -7,11 +7,14 @@ using System.Text;
 using System.Threading.Tasks;
 using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.Presets.Models;
+using NLog;
 
 namespace AnnoDesigner.Core.Presets.Loader
 {
     public class ColorPresetsLoader
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         public ColorPresets Load(string pathToColorPresetsFile)
         {
             ColorPresets result = null;
@@ -22,7 +25,7 @@ namespace AnnoDesigner.Core.Presets.Loader
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error loading the colors.{Environment.NewLine}{ex}");
+                logger.Error(ex, "Error loading the colors.");
                 throw;
             }
 
@@ -41,7 +44,7 @@ namespace AnnoDesigner.Core.Presets.Loader
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error loading the default scheme.{Environment.NewLine}{ex}");
+                logger.Error(ex, "Error loading the default scheme.");
                 throw;
             }
 

--- a/AnnoDesigner.Core/Presets/Loader/IconLoader.cs
+++ b/AnnoDesigner.Core/Presets/Loader/IconLoader.cs
@@ -1,6 +1,7 @@
 ﻿using AnnoDesigner.Core;
 using AnnoDesigner.Core.Models;
 using AnnoDesigner.Core.Presets.Models;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,6 +14,8 @@ namespace AnnoDesigner.Core.Presets.Loader
 {
     public class IconLoader
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         public Dictionary<string, IconImage> Load(string pathToIconFolder, IconMappingPresets iconNameMapping)
         {
             Dictionary<string, IconImage> result = null;
@@ -51,7 +54,7 @@ namespace AnnoDesigner.Core.Presets.Loader
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error loading the icons.{Environment.NewLine}{ex}");
+                logger.Error(ex, "Error loading the icons.");
                 throw;
             }
 

--- a/AnnoDesigner.Core/Presets/Loader/IconMappingPresetsLoader.cs
+++ b/AnnoDesigner.Core/Presets/Loader/IconMappingPresetsLoader.cs
@@ -1,5 +1,6 @@
 ﻿using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.Presets.Models;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,6 +16,8 @@ namespace AnnoDesigner.Core.Presets.Loader
     /// </summary>
     public class IconMappingPresetsLoader
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         public IconMappingPresets Load(string pathToIconNameMappingFile)
         {
             if (string.IsNullOrWhiteSpace(pathToIconNameMappingFile))
@@ -56,7 +59,7 @@ namespace AnnoDesigner.Core.Presets.Loader
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error loading the icon name mapping file.{Environment.NewLine}{ex}");
+                logger.Error(ex, "Error loading the icon name mapping file.");
                 throw;
             }
 

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -1116,7 +1116,7 @@
       <Version>4.6.7</Version>
     </PackageReference>
     <PackageReference Include="Octokit">
-      <Version>0.32.0</Version>
+      <Version>0.34.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -1111,6 +1111,9 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.0.1</Version>
     </PackageReference>
+    <PackageReference Include="NLog">
+      <Version>4.6.7</Version>
+    </PackageReference>
     <PackageReference Include="Octokit">
       <Version>0.32.0</Version>
     </PackageReference>

--- a/AnnoDesigner/Commons.cs
+++ b/AnnoDesigner/Commons.cs
@@ -1,4 +1,5 @@
 ﻿using AnnoDesigner.model;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,6 +12,8 @@ namespace AnnoDesigner
 {
     public class Commons : ICommons
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         #region ctor
 
         private static readonly Lazy<Commons> lazy = new Lazy<Commons>(() => new Commons());
@@ -61,7 +64,7 @@ namespace AnnoDesigner
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Cannot write to folder (\"{folderPathToCheck}\").{Environment.NewLine}{ex}");
+                logger.Error(ex, $"Cannot write to folder (\"{folderPathToCheck}\").");
             }
 
             return result;
@@ -91,7 +94,7 @@ namespace AnnoDesigner
                 psi.Verb = "runas";
             }
 
-            Trace.WriteLine($"{nameof(RestartApplication)} {nameof(asAdmin)}: {asAdmin}{Environment.NewLine}Path: \"{psi.FileName}\"{Environment.NewLine}Arguments: {psi.Arguments}");
+            logger.Trace($"{nameof(RestartApplication)} {nameof(asAdmin)}: {asAdmin}{Environment.NewLine}Path: \"{psi.FileName}\"{Environment.NewLine}Arguments: {psi.Arguments}");
 
             var process = new Process();
             process.StartInfo = psi;

--- a/AnnoDesigner/Localization/TreeLocalization.cs
+++ b/AnnoDesigner/Localization/TreeLocalization.cs
@@ -5,11 +5,14 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using AnnoDesigner.model;
+using NLog;
 
 namespace AnnoDesigner.Localization
 {
     public class TreeLocalization : ILocalizationHelper
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         public static Dictionary<string, Dictionary<string, string>> Translations;
 
         static TreeLocalization()
@@ -420,21 +423,21 @@ namespace AnnoDesigner.Localization
                 }
                 else
                 {
-                    Debug.WriteLine($"try to set localization to english for: : \"{valueToTranslate}\"");
+                    logger.Trace($"try to set localization to english for: : \"{valueToTranslate}\"");
                     if (Translations["eng"].TryGetValue(valueToTranslate.Replace(" ", string.Empty), out string engLocalization))
                     {
                         return engLocalization;
                     }
                     else
                     {
-                        Debug.WriteLine($"found no localization (\"eng\") and ({languageCode}) for : \"{valueToTranslate}\"");
+                        logger.Trace($"found no localization (\"eng\") and ({languageCode}) for : \"{valueToTranslate}\"");
                         return valueToTranslate;
                     }
                 }
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"error getting localization ({languageCode}) for: \"{valueToTranslate}\"{Environment.NewLine}{ex}");
+                logger.Error(ex, $"error getting localization ({languageCode}) for: \"{valueToTranslate}\"");
                 return valueToTranslate;
             }
         }

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -509,7 +509,7 @@ namespace AnnoDesigner
         private void StatusMessageChanged(string message)
         {
             StatusBarItemStatus.Content = message;
-            Debug.WriteLine($"Status message changed: {message}");
+            logger.Trace($"Status message changed: {message}");
         }
 
         private void LoadedFileChanged(string filename)
@@ -959,10 +959,10 @@ namespace AnnoDesigner
             // note: should be references to the correct copied objects from allObjects
             var selectedObjects = annoCanvas.SelectedObjects.Select(_ => new AnnoObject(_)).ToList();
 
-            Debug.WriteLine($"UI thread: {Thread.CurrentThread.ManagedThreadId} ({Thread.CurrentThread.Name})");
+            logger.Trace($"UI thread: {Thread.CurrentThread.ManagedThreadId} ({Thread.CurrentThread.Name})");
             void renderThread()
             {
-                Debug.WriteLine($"Render thread: {Thread.CurrentThread.ManagedThreadId} ({Thread.CurrentThread.Name})");
+                logger.Trace($"Render thread: {Thread.CurrentThread.ManagedThreadId} ({Thread.CurrentThread.Name})");
 
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
@@ -983,7 +983,7 @@ namespace AnnoDesigner
                 };
 
                 sw.Stop();
-                Debug.WriteLine($"creating canvas took: {sw.ElapsedMilliseconds}ms");
+                logger.Trace($"creating canvas took: {sw.ElapsedMilliseconds}ms");
 
                 // normalize layout
                 target.Normalize(border);

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -32,6 +32,7 @@ using AnnoDesigner.Core.Helper;
 using AnnoDesigner.viewmodel;
 using System.Windows.Threading;
 using AnnoDesigner.Helper;
+using NLog;
 
 namespace AnnoDesigner
 {
@@ -40,6 +41,7 @@ namespace AnnoDesigner
     /// </summary>
     public partial class MainWindow : Window, ICloseable
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
         private IconImage _noIconItem;
         private static MainWindow _instance;
 
@@ -100,7 +102,7 @@ namespace AnnoDesigner
             }
             catch (Exception ex)
             {
-                App.WriteToErrorLog("Error when changing the language.", ex.Message, ex.StackTrace);
+                logger.Error(ex, "Error when changing the language.");
             }
             finally
             {
@@ -305,8 +307,8 @@ namespace AnnoDesigner
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Error checking version. \n\nAdded error to error log.", "Version check failed");
-                    App.WriteToErrorLog("Error Checking Version", ex.Message, ex.StackTrace);
+                    logger.Error(ex, "Error checking version.");
+                    MessageBox.Show("Error checking version. \n\nAdded more information to log.", "Version check failed");
                     return;
                 }
             }
@@ -353,8 +355,8 @@ namespace AnnoDesigner
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Error checking version. \n\nAdded error to error log.", "Version check failed");
-                App.WriteToErrorLog("Error Checking Version", ex.Message, ex.StackTrace);
+                logger.Error(ex, "Error checking version.");
+                MessageBox.Show("Error checking version. \n\nAdded more information to log.", "Version check failed");
                 return;
             }
         }
@@ -507,13 +509,13 @@ namespace AnnoDesigner
         private void StatusMessageChanged(string message)
         {
             StatusBarItemStatus.Content = message;
-            System.Diagnostics.Debug.WriteLine(string.Format("Status message changed: {0}", message));
+            Debug.WriteLine($"Status message changed: {message}");
         }
 
         private void LoadedFileChanged(string filename)
         {
             Title = string.IsNullOrEmpty(filename) ? "Anno Designer" : string.Format("{0} - Anno Designer", Path.GetFileName(filename));
-            System.Diagnostics.Debug.WriteLine(string.Format("Loaded file: {0}", string.IsNullOrEmpty(filename) ? "(none)" : filename));
+            logger.Info($"Loaded file: {(string.IsNullOrEmpty(filename) ? "(none)" : filename)}");
         }
 
         private void ClipboardChanged(List<AnnoObject> l)
@@ -642,7 +644,7 @@ namespace AnnoDesigner
             }
             catch (Exception ex)
             {
-                App.WriteToErrorLog("Error in ApplyPreset()", ex.Message, ex.StackTrace);
+                logger.Error(ex, "Error applying preset.");
                 MessageBox.Show("Something went wrong while applying the preset.");
             }
         }
@@ -862,7 +864,7 @@ namespace AnnoDesigner
 
 #if DEBUG
             var userConfig = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal).FilePath;
-            Trace.WriteLine($"saving settings: \"{userConfig}\"");
+            logger.Trace($"saving settings: \"{userConfig}\"");
 #endif
         }
 
@@ -890,7 +892,7 @@ namespace AnnoDesigner
             }
             catch (Exception ex)
             {
-                App.WriteToErrorLog("Error saving layout to JSON", ex.Message, ex.StackTrace);
+                logger.Error(ex, "Error saving layout to JSON.");
                 MessageBox.Show(ex.Message, "Something went wrong while saving the layout.");
             }
         }
@@ -926,10 +928,13 @@ namespace AnnoDesigner
                         MessageBoxButton.OK,
                         MessageBoxImage.Information);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    App.WriteToErrorLog("Error exporting image", e.Message, e.StackTrace);
-                    MessageBox.Show(e.Message, "Something went wrong while exporting the image.");
+                    logger.Error(ex, "Error exporting image.");
+                    MessageBox.Show("Something went wrong while exporting the image.",
+                        Localization.Localization.Translations[Localization.Localization.GetLanguageCodeFromName(SelectedLanguage)]["Error"],
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
                 }
             }
         }
@@ -1077,7 +1082,7 @@ namespace AnnoDesigner
             }
             catch (LayoutFileVersionMismatchException layoutEx)
             {
-                Trace.WriteLine(layoutEx);
+                logger.Warn(layoutEx, "Version of layout does not match.");
 
                 if (MessageBox.Show(
                         "Try loading anyway?\nThis is very likely to fail or result in strange things happening.",
@@ -1086,10 +1091,13 @@ namespace AnnoDesigner
                     LoadLayoutFromJson(jsonString, true);
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                App.WriteToErrorLog("Error loading layout from JSON", e.Message, e.StackTrace);
-                MessageBox.Show(e.Message, "Something went wrong while loading the layout.");
+                logger.Error(ex, "Error loading layout from JSON.");
+                MessageBox.Show("Something went wrong while loading the layout.",
+                        Localization.Localization.Translations[Localization.Localization.GetLanguageCodeFromName(SelectedLanguage)]["Error"],
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
             }
         }
     }

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -123,26 +123,31 @@
 
         <variable name="logDirectory" value="logs" />
         <variable name="archiveDirectory" value="${logDirectory}//archive" />
-        <variable name="logFileName" value="Logfile_AnnoDesigner_${date:universalTime=true:format=yyyyMMdd}" />
+        <variable name="logFileName" value="Logfile_AnnoDesigner" />
         <targets async="false">
-            <default-target-parameters xsi:type="File"
-                                       archiveEvery="Day"
-                                       archiveNumbering="Sequence"
-                                       concurrentWrites="false"
-                                       keepFileOpen="true"
-                                       autoFlush="true"
-                                       encoding="utf-8"
-                                       createDirs="true"
-                                       lineEnding="CRLF"
-                                       enableArchiveFileCompression="true"
-                                       openFileCacheTimeout="30" />
+            <!--
+            https://github.com/NLog/NLog/wiki/File-target#archive-old-log-files
+            If the fileName is static and doesn't include a ${date} layout, then you can use archiveEvery="Day" to ensure that it starts a new logfile every day.
+            If the fileName does include ${date} layout, then you should NOT configure archiveEvery.
+            -->
             <target name="MainLogger"
                     xsi:type="File"
                     layout="${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}||${pad:padding=-5:inner=${level:uppercase=true}}||${logger}||${message:withException=false:whenEmpty=(no message)}${onexception:${newline}${exception:format=ToString,Data:separator=&#xD;&#xA;:maxInnerExceptionLevel=20:innerFormat=ToString,Data:innerExceptionSeparator=&#xD;&#xA;++++++++++&#xD;&#xA;:exceptionDataSeparator=&#xD;&#xA;}"
+                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program"
                     fileName="${var:logDirectory}/${var:logFileName}.txt"
-                    archiveFileName="${var:archiveDirectory}/${var:logFileName}.{####}.zip"
+                    archiveFileName="${var:archiveDirectory}/${var:logFileName}_{#}.zip"
                     maxArchiveFiles="7"
-                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program" />
+                    archiveEvery="Day"
+                    archiveNumbering="Date"
+                    archiveDateFormat="yyyyMMdd"
+                    enableArchiveFileCompression="true"
+                    encoding="utf-8"
+                    createDirs="true"
+                    lineEnding="CRLF"
+                    concurrentWrites="false"
+                    keepFileOpen="true"
+                    autoFlush="true"
+                    openFileCacheTimeout="30" />
         </targets>
         <targets async="true">
             <target name="Debugger" xsi:type="Debugger" layout="${message:whenEmpty=(no message)}" />

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -7,6 +7,7 @@
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="AnnoDesigner.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
         </sectionGroup>
+        <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
     </configSections>
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
@@ -98,12 +99,61 @@
             </setting>
         </AnnoDesigner.Properties.Settings>
     </applicationSettings>
-    <!--<system.diagnostics>
-        <trace autoflush="true" indentsize="4">
+    <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" autoReload="true">
+        <!--internalLogFile="internal_log_file.txt"
+        internalLogLevel="Trace"
+        internalLogToTrace="true"
+        -->
+        <!--
+        many examples:
+        http://stackoverflow.com/questions/4091606/most-useful-nlog-configurations/
+        
+        The following are the allowed log levels (in order):
+        Fatal
+        Error
+        Warn
+        Info
+        Debug
+        Trace
+        Off
+        -->
+
+        <variable name="logDirectory" value="logs" />
+        <variable name="archiveDirectory" value="${logDirectory}//archive" />
+        <variable name="logFileName" value="Logfile_AnnoDesigner" />
+        <targets async="false">
+            <default-target-parameters xsi:type="File"
+                                       archiveEvery="Day"
+                                       archiveNumbering="Sequence"
+                                       concurrentWrites="false"
+                                       keepFileOpen="true"
+                                       autoFlush="true"
+                                       encoding="utf-8"
+                                       createDirs="true"
+                                       lineEnding="CRLF"
+                                       enableArchiveFileCompression="true"
+                                       openFileCacheTimeout="30" />
+            <target name="MainLogger"
+                    xsi:type="File"
+                    layout="${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}||${pad:padding=-5:inner=${level:uppercase=true}}||${logger}||${message:withException=false:whenEmpty=(no message)}${onexception:${newline}${exception:format=ToString,Data:separator=&#xD;&#xA;:maxInnerExceptionLevel=20:innerFormat=ToString,Data:innerExceptionSeparator=&#xD;&#xA;++++++++++&#xD;&#xA;:exceptionDataSeparator=&#xD;&#xA;}"
+                    fileName="${var:logDirectory}/${var:logFileName}.txt"
+                    archiveFileName="${var:archiveDirectory}/${var:logFileName}.{####}.zip"
+                    maxArchiveFiles="7"
+                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program" />
+        </targets>
+        <targets async="true">
+            <target name="Debugger" xsi:type="Debugger" layout="${message:whenEmpty=(no message)}" />
+        </targets>
+        <rules>
+            <logger name="*" minlevel="Trace" writeTo="MainLogger" />
+            <logger name="*" minlevel="Trace" writeTo="Debugger" />
+        </rules>
+    </nlog>
+    <system.diagnostics>
+        <trace autoflush="true">
             <listeners>
-                <add name="myListener" type="System.Diagnostics.TextWriterTraceListener" initializeData="application.log" />
-                <remove name="Default" />
+                <add name="NLogTraceListener" type="NLog.NLogTraceListener, NLog" />
             </listeners>
         </trace>
-    </system.diagnostics>-->
+    </system.diagnostics>
 </configuration>

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -123,7 +123,7 @@
 
         <variable name="logDirectory" value="logs" />
         <variable name="archiveDirectory" value="${logDirectory}//archive" />
-        <variable name="logFileName" value="Logfile_AnnoDesigner" />
+        <variable name="logFileName" value="Logfile_AnnoDesigner_${date:universalTime=true:format=yyyyMMdd}" />
         <targets async="false">
             <default-target-parameters xsi:type="File"
                                        archiveEvery="Day"
@@ -148,7 +148,7 @@
             <target name="Debugger" xsi:type="Debugger" layout="${message:whenEmpty=(no message)}" />
         </targets>
         <rules>
-            <logger name="*" minlevel="Trace" writeTo="MainLogger" />
+            <logger name="*" minlevel="Debug" writeTo="MainLogger" />
             <logger name="*" minlevel="Trace" writeTo="Debugger" />
         </rules>
     </nlog>

--- a/AnnoDesigner/viewmodel/BuildingSettingsViewModel.cs
+++ b/AnnoDesigner/viewmodel/BuildingSettingsViewModel.cs
@@ -3,6 +3,7 @@ using AnnoDesigner.Core.Presets.Helper;
 using AnnoDesigner.Core.Presets.Models;
 using AnnoDesigner.model;
 using AnnoDesigner.Properties;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,6 +17,8 @@ namespace AnnoDesigner.viewmodel
 {
     public class BuildingSettingsViewModel : Notify
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         private string _textHeader;
         private string _textSize;
         private string _textColor;
@@ -491,7 +494,7 @@ namespace AnnoDesigner.viewmodel
 
             if (!GetDistanceRange(IsPavedStreet, AnnoCanvasToUse.BuildingPresets.Buildings.FirstOrDefault(_ => _.Identifier == BuildingIdentifier)))
             {
-                Debug.WriteLine("$Calculate Paved Street/Dirt Street Error: Can not obtain new Distance Value, value set to 0");
+                logger.Trace("$Calculate Paved Street/Dirt Street Error: Can not obtain new Distance Value, value set to 0");
             }
             else
             {

--- a/AnnoDesigner/viewmodel/PresetsTreeViewModel.cs
+++ b/AnnoDesigner/viewmodel/PresetsTreeViewModel.cs
@@ -14,11 +14,14 @@ using AnnoDesigner.Core.Presets.Comparer;
 using AnnoDesigner.Core.Presets.Models;
 using AnnoDesigner.model;
 using AnnoDesigner.model.PresetsTree;
+using NLog;
 
 namespace AnnoDesigner.viewmodel
 {
     public class PresetsTreeViewModel : Notify
     {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         public event EventHandler<EventArgs> ApplySelectedItem;
 
         private readonly ILocalizationHelper _localizationHelper;
@@ -282,7 +285,7 @@ namespace AnnoDesigner.viewmodel
 
 #if DEBUG
             sw.Stop();
-            Debug.WriteLine($"loading items for PresetsTree took: {sw.ElapsedMilliseconds}ms");
+            logger.Trace($"loading items for PresetsTree took: {sw.ElapsedMilliseconds}ms");
 #endif
         }
 

--- a/ColorPresetsDesigner/App.config
+++ b/ColorPresetsDesigner/App.config
@@ -45,30 +45,35 @@
         <variable name="archiveDirectory" value="${logDirectory}//archive" />
         <variable name="logFileName" value="Logfile_ColorPresetsDesigner" />
         <targets async="false">
-            <default-target-parameters xsi:type="File"
-                                       archiveEvery="Day"
-                                       archiveNumbering="Sequence"
-                                       concurrentWrites="false"
-                                       keepFileOpen="true"
-                                       autoFlush="true"
-                                       encoding="utf-8"
-                                       createDirs="true"
-                                       lineEnding="CRLF"
-                                       enableArchiveFileCompression="true"
-                                       openFileCacheTimeout="30" />
+            <!--
+            https://github.com/NLog/NLog/wiki/File-target#archive-old-log-files
+            If the fileName is static and doesn't include a ${date} layout, then you can use archiveEvery="Day" to ensure that it starts a new logfile every day.
+            If the fileName does include ${date} layout, then you should NOT configure archiveEvery.
+            -->
             <target name="MainLogger"
                     xsi:type="File"
                     layout="${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}||${pad:padding=-5:inner=${level:uppercase=true}}||${logger}||${message:withException=false:whenEmpty=(no message)}${onexception:${newline}${exception:format=ToString,Data:separator=&#xD;&#xA;:maxInnerExceptionLevel=20:innerFormat=ToString,Data:innerExceptionSeparator=&#xD;&#xA;++++++++++&#xD;&#xA;:exceptionDataSeparator=&#xD;&#xA;}"
+                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program"
                     fileName="${var:logDirectory}/${var:logFileName}.txt"
-                    archiveFileName="${var:archiveDirectory}/${var:logFileName}.{####}.zip"
+                    archiveFileName="${var:archiveDirectory}/${var:logFileName}_{#}.zip"
                     maxArchiveFiles="7"
-                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program" />
+                    archiveEvery="Day"
+                    archiveNumbering="Date"
+                    archiveDateFormat="yyyyMMdd"
+                    enableArchiveFileCompression="true"
+                    encoding="utf-8"
+                    createDirs="true"
+                    lineEnding="CRLF"
+                    concurrentWrites="false"
+                    keepFileOpen="true"
+                    autoFlush="true"
+                    openFileCacheTimeout="30" />
         </targets>
         <targets async="true">
             <target name="Debugger" xsi:type="Debugger" layout="${message:whenEmpty=(no message)}" />
         </targets>
         <rules>
-            <logger name="*" minlevel="Trace" writeTo="MainLogger" />
+            <logger name="*" minlevel="Debug" writeTo="MainLogger" />
             <logger name="*" minlevel="Trace" writeTo="Debugger" />
         </rules>
     </nlog>

--- a/ColorPresetsDesigner/ColorPresetsDesigner.csproj
+++ b/ColorPresetsDesigner/ColorPresetsDesigner.csproj
@@ -131,7 +131,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.6.5</Version>
+      <Version>4.6.7</Version>
     </PackageReference>
     <PackageReference Include="WindowsAPICodePack-Core">
       <Version>1.1.2</Version>

--- a/FandomParser/FandomParser/App.config
+++ b/FandomParser/FandomParser/App.config
@@ -29,30 +29,35 @@
         <variable name="archiveDirectory" value="${logDirectory}//archive" />
         <variable name="logFileName" value="Logfile_FandomParser" />
         <targets async="false">
-            <default-target-parameters xsi:type="File"
-                                       archiveEvery="Day"
-                                       archiveNumbering="Sequence"
-                                       concurrentWrites="false"
-                                       keepFileOpen="true"
-                                       autoFlush="true"
-                                       encoding="utf-8"
-                                       createDirs="true"
-                                       lineEnding="CRLF"
-                                       enableArchiveFileCompression="true"
-                                       openFileCacheTimeout="30" />
+            <!--
+            https://github.com/NLog/NLog/wiki/File-target#archive-old-log-files
+            If the fileName is static and doesn't include a ${date} layout, then you can use archiveEvery="Day" to ensure that it starts a new logfile every day.
+            If the fileName does include ${date} layout, then you should NOT configure archiveEvery.
+            -->
             <target name="MainLogger"
                     xsi:type="File"
                     layout="${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}||${pad:padding=-5:inner=${level:uppercase=true}}||${logger}||${message:withException=false:whenEmpty=(no message)}${onexception:${newline}${exception:format=ToString,Data:separator=&#xD;&#xA;:maxInnerExceptionLevel=20:innerFormat=ToString,Data:innerExceptionSeparator=&#xD;&#xA;++++++++++&#xD;&#xA;:exceptionDataSeparator=&#xD;&#xA;}"
+                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program"
                     fileName="${var:logDirectory}/${var:logFileName}.txt"
-                    archiveFileName="${var:archiveDirectory}/${var:logFileName}.{####}.zip"
+                    archiveFileName="${var:archiveDirectory}/${var:logFileName}_{#}.zip"
                     maxArchiveFiles="7"
-                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program" />
+                    archiveEvery="Day"
+                    archiveNumbering="Date"
+                    archiveDateFormat="yyyyMMdd"
+                    enableArchiveFileCompression="true"
+                    encoding="utf-8"
+                    createDirs="true"
+                    lineEnding="CRLF"
+                    concurrentWrites="false"
+                    keepFileOpen="true"
+                    autoFlush="true"
+                    openFileCacheTimeout="30" />
         </targets>
         <targets async="true">
             <target name="Debugger" xsi:type="Debugger" layout="${message:whenEmpty=(no message)}" />
         </targets>
         <rules>
-            <logger name="*" minlevel="Trace" writeTo="MainLogger" />
+            <logger name="*" minlevel="Debug" writeTo="MainLogger" />
             <logger name="*" minlevel="Trace" writeTo="Debugger" />
         </rules>
     </nlog>

--- a/FandomParser/FandomParser/FandomParser.csproj
+++ b/FandomParser/FandomParser/FandomParser.csproj
@@ -68,7 +68,7 @@
       <Version>0.6.5</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.6.5</Version>
+      <Version>4.6.7</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/FandomParser/Tests/InfoboxParser.Tests/InfoboxParser.Tests.csproj
+++ b/FandomParser/Tests/InfoboxParser.Tests/InfoboxParser.Tests.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.11.0</Version>
+      <Version>4.13.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/FandomTemplateExporter/FandomTemplateExporter/App.config
+++ b/FandomTemplateExporter/FandomTemplateExporter/App.config
@@ -48,30 +48,35 @@
         <variable name="archiveDirectory" value="${logDirectory}//archive" />
         <variable name="logFileName" value="Logfile_FandomTemplateExporter" />
         <targets async="false">
-            <default-target-parameters xsi:type="File"
-                                       archiveEvery="Day"
-                                       archiveNumbering="Sequence"
-                                       concurrentWrites="false"
-                                       keepFileOpen="true"
-                                       autoFlush="true"
-                                       encoding="utf-8"
-                                       createDirs="true"
-                                       lineEnding="CRLF"
-                                       enableArchiveFileCompression="true"
-                                       openFileCacheTimeout="30" />
+            <!--
+            https://github.com/NLog/NLog/wiki/File-target#archive-old-log-files
+            If the fileName is static and doesn't include a ${date} layout, then you can use archiveEvery="Day" to ensure that it starts a new logfile every day.
+            If the fileName does include ${date} layout, then you should NOT configure archiveEvery.
+            -->
             <target name="MainLogger"
                     xsi:type="File"
                     layout="${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}||${pad:padding=-5:inner=${level:uppercase=true}}||${logger}||${message:withException=false:whenEmpty=(no message)}${onexception:${newline}${exception:format=ToString,Data:separator=&#xD;&#xA;:maxInnerExceptionLevel=20:innerFormat=ToString,Data:innerExceptionSeparator=&#xD;&#xA;++++++++++&#xD;&#xA;:exceptionDataSeparator=&#xD;&#xA;}"
+                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program"
                     fileName="${var:logDirectory}/${var:logFileName}.txt"
-                    archiveFileName="${var:archiveDirectory}/${var:logFileName}.{####}.zip"
+                    archiveFileName="${var:archiveDirectory}/${var:logFileName}_{#}.zip"
                     maxArchiveFiles="7"
-                    footer="----------|${pad:padding=-19:inner=${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss}}|end of program" />
+                    archiveEvery="Day"
+                    archiveNumbering="Date"
+                    archiveDateFormat="yyyyMMdd"
+                    enableArchiveFileCompression="true"
+                    encoding="utf-8"
+                    createDirs="true"
+                    lineEnding="CRLF"
+                    concurrentWrites="false"
+                    keepFileOpen="true"
+                    autoFlush="true"
+                    openFileCacheTimeout="30" />
         </targets>
         <targets async="true">
             <target name="Debugger" xsi:type="Debugger" layout="${message:whenEmpty=(no message)}" />
         </targets>
         <rules>
-            <logger name="*" minlevel="Trace" writeTo="MainLogger" />
+            <logger name="*" minlevel="Debug" writeTo="MainLogger" />
             <logger name="*" minlevel="Trace" writeTo="Debugger" />
         </rules>
     </nlog>

--- a/FandomTemplateExporter/FandomTemplateExporter/FandomTemplateExporter.csproj
+++ b/FandomTemplateExporter/FandomTemplateExporter/FandomTemplateExporter.csproj
@@ -140,7 +140,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.6.5</Version>
+      <Version>4.6.7</Version>
     </PackageReference>
     <PackageReference Include="WindowsAPICodePack-Core">
       <Version>1.1.2</Version>

--- a/PresetParser/PresetParser.csproj
+++ b/PresetParser/PresetParser.csproj
@@ -93,7 +93,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions">
-      <Version>6.0.7</Version>
+      <Version>6.0.32</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/AnnoDesigner.Core.Tests/AnnoDesigner.Core.Tests.csproj
+++ b/Tests/AnnoDesigner.Core.Tests/AnnoDesigner.Core.Tests.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.12.0</Version>
+      <Version>4.13.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/Tests/AnnoDesigner.Tests/AnnoDesigner.Tests.csproj
+++ b/Tests/AnnoDesigner.Tests/AnnoDesigner.Tests.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.12.0</Version>
+      <Version>4.13.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/Tests/PresetParser.Tests/PresetParser.Tests.csproj
+++ b/Tests/PresetParser.Tests/PresetParser.Tests.csproj
@@ -52,10 +52,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.12.0</Version>
+      <Version>4.13.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions.TestingHelpers">
-      <Version>6.0.11</Version>
+      <Version>6.0.32</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/build/build.cake
+++ b/build/build.cake
@@ -271,6 +271,7 @@ var copyFilesTask = Task("Copy-Files")
     CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/colors.json", $"{outDirectory}");
     CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/icons.json", $"{outDirectory}");
     CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/Microsoft.Xaml.Behaviors.dll", $"{outDirectory}");
+    CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/NLog.dll", $"{outDirectory}");
     CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/Octokit.dll", $"{outDirectory}");
     CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/presets.json", $"{outDirectory}");
     CopyFileToDirectory($"./../AnnoDesigner/bin/{configuration}/Xceed.Wpf.Toolkit.dll", $"{outDirectory}");


### PR DESCRIPTION
This PR should fix #122.
With this PR there are proper formatted log files in a common location (directory "logs" app directory).
The added logging framework is [NLog](https://nlog-project.org/).
The format of those log files can be adjusted (via app.config) and currently the log files of the last 7 days will be kept in an archive as zip-files.
The current format is:
`Timestamp||Level||Logger||Message`
Example:
`2019-09-26 14:14:51||INFO ||AnnoDesigner.App||program version: 8.2.0.0`

In case of an error there will be plenty of information in the log (e.g. StackTrace, ExceptionData, InnerExceptions).
Example (german runtime):

> 2019-09-26 13:22:10||ERROR||AnnoDesigner.App||Application.Current.DispatcherUnhandledException
> System.Exception: Testexception that is thrown on purpose. ---> System.Exception: This is the inner exception for test.
>    --- Ende der internen Ausnahmestapelüberwachung ---
>    bei AnnoDesigner.MainWindow.LoadedFileChanged(String filename) in C:\Workspace\github\anno-designer\AnnoDesigner\MainWindow.xaml.cs:Zeile 524.
>    bei AnnoDesigner.AnnoCanvas.set_LoadedFile(String value) in C:\Workspace\github\anno-designer\AnnoDesigner\AnnoCanvas.xaml.cs:Zeile 262.
>    bei AnnoDesigner.AnnoCanvas.SaveAs() in C:\Workspace\github\anno-designer\AnnoDesigner\AnnoCanvas.xaml.cs:Zeile 1584.
>    bei AnnoDesigner.AnnoCanvas.<>c.<.cctor>b__121_3(AnnoCanvas _) in C:\Workspace\github\anno-designer\AnnoDesigner\AnnoCanvas.xaml.cs:Zeile 1672.
>    bei AnnoDesigner.AnnoCanvas.ExecuteCommand(Object sender, ExecutedRoutedEventArgs e) in C:\Workspace\github\anno-designer\AnnoDesigner\AnnoCanvas.xaml.cs:Zeile 1691.
>    bei System.Windows.Input.CommandBinding.OnExecuted(Object sender, ExecutedRoutedEventArgs e)
>    bei System.Windows.Input.CommandManager.ExecuteCommandBinding(Object sender, ExecutedRoutedEventArgs e, CommandBinding commandBinding)
>    bei System.Windows.Input.CommandManager.FindCommandBinding(Object sender, RoutedEventArgs e, ICommand command, Boolean execute)
>    bei System.Windows.Input.CommandManager.OnExecuted(Object sender, ExecutedRoutedEventArgs e)
>    bei System.Windows.UIElement.OnExecutedThunk(Object sender, ExecutedRoutedEventArgs e)
>    bei System.Windows.Input.ExecutedRoutedEventArgs.InvokeEventHandler(Delegate genericHandler, Object target)
>    bei System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
>    bei System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
>    bei System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
>    bei System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
>    bei System.Windows.UIElement.RaiseEvent(RoutedEventArgs args, Boolean trusted)
>    bei System.Windows.Input.RoutedCommand.ExecuteImpl(Object parameter, IInputElement target, Boolean userInitiated)
>    bei System.Windows.Input.RoutedCommand.ExecuteCore(Object parameter, IInputElement target, Boolean userInitiated)
>    bei MS.Internal.Commands.CommandHelpers.CriticalExecuteCommandSource(ICommandSource commandSource, Boolean userInitiated)
>    bei System.Windows.Controls.MenuItem.InvokeClickAfterRender(Object arg)
>    bei System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
>    bei System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
> AdditionalDataKey: AdditionalDataValue e.g. some special value from settings
> System.Object: 
> ++++++++++
> System.Exception: This is the inner exception for test.
> DataKey: The inner exception can contain additional data too.

At the end of every app session there will be a special log entry to make it easier for developers to read the log file:
`----------|2019-09-26 13:22:20|end of program`

Attached are some example log-files.
[logs.zip](https://github.com/AgmasGold/anno-designer/files/3661456/logs.zip)


