### PR TITLE
adjust license structure to autorecognize it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,31 +1,6 @@
 MIT License
 
-Copyright (c) 2011 - 2013 jc.bernak
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-MIT License
-
-Copyright (c) 2019 Agmas, Sting_McRay
-
+Copyright (c) 2011 - 2013 jc.bernak, 2019 Agmas, Sting_McRay
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This adjusts the structure of the license file so GitHub can recognize it automatically.

I just merged the "Copyright ..." lines so it is recognized as the ususal template used by GitHub.

current state:
![license_not_recognized](https://user-images.githubusercontent.com/6222752/66457011-972ba480-ea6f-11e9-8b8e-9f30dd2b8371.png)
expected state:
![license_recognized](https://user-images.githubusercontent.com/6222752/66457031-a1e63980-ea6f-11e9-8266-fb66d7cb0548.png)

