### PR TITLE
draw selection before influence

### DIFF
--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -561,11 +561,11 @@ namespace AnnoDesigner
             // draw mouse grid position highlight
             //drawingContext.DrawRectangle(_lightBrush, _highlightPen, new Rect(GridToScreen(ScreenToGrid(_mousePosition)), new Size(_gridStep, _gridStep)));
 
-            // draw placed objects
+            // draw placed objects            
             RenderObjectList(drawingContext, _placedObjects, useTransparency: false);
+            _selectedObjects.ForEach(_ => RenderObjectSelection(drawingContext, _));
             RenderObjectInfluenceRadius(drawingContext, _selectedObjects);
             RenderObjectInfluenceRange(drawingContext, _selectedObjects);
-            _selectedObjects.ForEach(_ => RenderObjectSelection(drawingContext, _));
 
             if (CurrentObjects.Count == 0)
             {


### PR DESCRIPTION
This PR changes the order of drawing the selection.
New behaviour is on the left side:
![selection-compare](https://user-images.githubusercontent.com/6222752/66672901-b5f08d80-ec5f-11e9-83cf-ac1aa0f63ef9.png)
